### PR TITLE
Lockhammer: improve command line arg parsing

### DIFF
--- a/benchmarks/lockhammer/Makefile
+++ b/benchmarks/lockhammer/Makefile
@@ -6,19 +6,25 @@ LDFLAGS=-lpthread
 lh_%: tests/%.h include/atomics.h src/lockhammer.c 
 	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
 
-all: \
-	lh_swap_mutex \
+TARGET_ARCH:=$(shell ${CC} -dumpmachine | cut -d '-' -f 1)
+
+TEST_TARGETS=lh_swap_mutex \
 	lh_event_mutex \
 	lh_cas_event_mutex \
 	lh_cas_lockref \
 	lh_cas_rw_lock \
 	lh_incdec_refcount \
 	lh_ticket_spinlock \
-	lh_hybrid_spinlock \
-	lh_hybrid_spinlock_fastdequeue \
 	lh_queued_spinlock \
 	lh_empty \
 	lh_jvm_objectmonitor
+
+ifeq ($(TARGET_ARCH),aarch64)
+	TEST_TARGETS+=lh_hybrid_spinlock \
+		lh_hybrid_spinlock_fastdequeue
+endif
+
+all: ${TEST_TARGETS}
 
 lh_event_mutex: ../../ext/mysql/event_mutex.h include/atomics.h ../../ext/mysql/include/ut_atomics.h src/lockhammer.c
 	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}

--- a/benchmarks/lockhammer/include/atomics.h
+++ b/benchmarks/lockhammer/include/atomics.h
@@ -34,6 +34,9 @@
 #ifndef initialize_lock
 	#define initialize_lock(lock, thread)
 #endif
+#ifndef parse_test_args
+	#define parse_test_args(args, argc, argv)
+#endif
 
 static inline void spin_wait (unsigned long wait_iter) {
 #if defined(__aarch64__)

--- a/benchmarks/lockhammer/include/lockhammer.h
+++ b/benchmarks/lockhammer/include/lockhammer.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LOCKHAMMER_H__
+#define __LOCKHAMMER_H__
+
+struct thread_args {
+    unsigned long ncores;
+    unsigned long nthrds;
+    unsigned long iter;
+    unsigned long *lock;
+    unsigned long *rst;
+    unsigned long *nsec;
+    unsigned long *depth;
+    unsigned long *nstart;
+    unsigned long hold, post;
+};
+typedef struct thread_args thread_args;
+
+struct test_args {
+    unsigned long nthrds;
+    unsigned long nacqrs;
+    unsigned long ncrit;
+    unsigned long nparallel;
+};
+typedef struct test_args test_args;
+
+#endif

--- a/benchmarks/lockhammer/scripts/sweep.sh
+++ b/benchmarks/lockhammer/scripts/sweep.sh
@@ -48,7 +48,7 @@ do
 		fi
 
 		echo Test: ${1} CPU: exectx=$c Date: `date` 1>&2
-		sudo ../build/lh_${1} $c ${acquires} ${2} ${3}
+		sudo ../build/lh_${1} -t $c -a ${acquires} -c ${2} -p ${3}
 		sleep 5s
 	fi
 done

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -81,21 +81,52 @@ int main(int argc, char** argv)
 
     while ((i = getopt(argc, argv, "t:a:c:p:")) != -1)
     {
+        long optval = 0;
         switch (i) {
           case 't':
-            args.nthrds = strtol(optarg, (char **) NULL, 10);
+            optval = strtol(optarg, (char **) NULL, 10);
             /* Do not allow number of threads to exceed online cores
                in order to prevent deadlock ... */
-            args.nthrds > num_cores ? num_cores : args.nthrds;
+            if (optval < 0) {
+                fprintf(stderr, "ERROR: thread count must be positive.\n");
+                return 1;
+            }
+            else if (optval <= num_cores) {
+                args.nthrds = optval;
+            }
+            else {
+                fprintf(stderr, "WARNING: limiting thread count to online cores (%d).\n", num_cores);
+            }
             break;
           case 'a':
-            args.nacqrs = strtol(optarg, (char **) NULL, 10);
+            optval = strtol(optarg, (char **) NULL, 10);
+            if (optval < 0) {
+                fprintf(stderr, "ERROR: acquire count must be positive.\n");
+                return 1;
+            }
+            else {
+                args.nacqrs = optval;
+            }
             break;
           case 'c':
-            args.ncrit = strtol(optarg, (char **) NULL, 10);
+            optval = strtol(optarg, (char **) NULL, 10);
+            if (optval < 0) {
+                fprintf(stderr, "ERROR: critical iteration count must be positive.\n");
+                return 1;
+            }
+            else {
+                args.ncrit = optval;
+            }
             break;
           case 'p':
-            args.nparallel = strtol(optarg, (char **) NULL, 10);
+            optval = strtol(optarg, (char **) NULL, 10);
+            if (optval < 0) {
+                fprintf(stderr, "ERROR: parallel iteration count must be positive.\n");
+                return 1;
+            }
+            else {
+                args.nparallel = optval;
+            }
             break;
           case '?':
           default:

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -108,6 +108,7 @@ int main(int argc, char** argv)
                 break;
               default:
                 print_usage(argv[0]);
+                return 1;
             }
             if (errno == EINVAL) {
                 print_usage(argv[0]);

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -53,9 +53,9 @@ void* hmr(void *);
 
 void print_usage (char *invoc) {
     fprintf(stderr,
-"Usage: %s\n\t[-t threads]\n\t[-a acquires per thread]\n\t" \
-"[-c critical iterations]\n\t[-p parallelizable iterations]\n\t" \
-"[-- <test specific arguments>]\n", invoc);
+            "Usage: %s\n\t[-t threads]\n\t[-a acquires per thread]\n\t"
+            "[-c critical iterations]\n\t[-p parallelizable iterations]\n\t"
+            "[-- <test specific arguments>]\n", invoc);
 }
 
 int main(int argc, char** argv)
@@ -77,49 +77,34 @@ int main(int argc, char** argv)
                        .ncrit = 0,
                        .nparallel = 0 };
 
-    for (i = 1; i < argc; i++) {
-        if (strlen(argv[i]) == 2 && argv[i][0] == '-' && i < argc) {
-            switch (argv[i][1]) {
-              case 't':
-                i++;
-                args.nthrds = strtol(argv[i], (char **) NULL, 10);
-                /* Do not allow number of threads to exceed online cores
-                   in order to prevent deadlock ... */
-                args.nthrds > num_cores ? num_cores : args.nthrds;
-                break;
-              case 'a':
-                i++;
-                args.nacqrs = strtol(argv[i], (char **) NULL, 10);
-                break;
-              case 'c':
-                i++;
-                args.ncrit = strtol(argv[i], (char **) NULL, 10);
-                break;
-              case 'p':
-                i++;
-                args.nparallel = strtol(argv[i], (char **) NULL, 10);
-                break;
-              case '-':
-                /* anything after "--" is ignore and passed through to test */
-                i++;
-                parse_test_args(args, argc - i, &argv[i]);
-                /* skip over remaining args since they are parsed by test */
-                i = argc;
-                break;
-              default:
-                print_usage(argv[0]);
-                return 1;
-            }
-            if (errno == EINVAL) {
-                print_usage(argv[0]);
-                return 1;
-            }
-        }
-        else {
+    opterr = 0;
+
+    while ((i = getopt(argc, argv, "t:a:c:p:")) != -1)
+    {
+        switch (i) {
+          case 't':
+            args.nthrds = strtol(optarg, (char **) NULL, 10);
+            /* Do not allow number of threads to exceed online cores
+               in order to prevent deadlock ... */
+            args.nthrds > num_cores ? num_cores : args.nthrds;
+            break;
+          case 'a':
+            args.nacqrs = strtol(optarg, (char **) NULL, 10);
+            break;
+          case 'c':
+            args.ncrit = strtol(optarg, (char **) NULL, 10);
+            break;
+          case 'p':
+            args.nparallel = strtol(optarg, (char **) NULL, 10);
+            break;
+          case '?':
+          default:
             print_usage(argv[0]);
             return 1;
         }
     }
+
+    parse_test_args(args, argc - optind, &argv[optind]);
 
     pthread_t hmr_threads[args.nthrds];
     pthread_attr_t hmr_attr;

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -41,32 +41,13 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "lockhammer.h"
+
 #include ATOMIC_TEST
 
 uint64_t test_lock = 0;
 uint64_t sync_lock = 0;
 uint64_t ready_lock = 0;
-
-struct thread_args {
-    unsigned long ncores;
-    unsigned long nthrds;
-    unsigned long iter;
-    unsigned long *lock;
-    unsigned long *rst;
-    unsigned long *nsec;
-    unsigned long *depth;
-    unsigned long *nstart;
-    unsigned long hold, post;
-};
-typedef struct thread_args thread_args;
-
-struct test_args {
-    unsigned long nthrds;
-    unsigned long nacqrs;
-    unsigned long ncrit;
-    unsigned long nparallel;
-};
-typedef struct test_args test_args;
 
 void* hmr(void *);
 


### PR DESCRIPTION
Convert argument parsing from only default/full specification to
incremental flags and parameters.  Additionally allow for test-
specific arguments to be provided on the command line following
"--".

Fixes #7

Change-Id: Ia97684b6b6df72f2fb8f057a73182aae31f6276f
Signed-off-by: Lucas Crowthers <lucasc.qdt@qualcommdatacenter.com>