### PR TITLE
Lockhammer: Introduce TB spin_rw_mutex test

### DIFF
--- a/benchmarks/lockhammer/Makefile
+++ b/benchmarks/lockhammer/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -O2 -I. -I./include -I../../ext/mysql/include -I../../ext/linux/include
+CFLAGS=-g -O2 -I. -I./include -I../../ext/mysql/include -I../../ext/linux/include -I../../ext/tbb/include
 LDFLAGS=-lpthread
 # LSE support is experimental, please enable the below CFLAGS with caution
 # CFLAGS=-O2 -march=armv8-a+lse -DUSE_LSE -I. -I./include -I../../ext/mysql/include -I../../ext/linux/include
@@ -17,7 +17,8 @@ TEST_TARGETS=lh_swap_mutex \
 	lh_ticket_spinlock \
 	lh_queued_spinlock \
 	lh_empty \
-	lh_jvm_objectmonitor
+	lh_jvm_objectmonitor \
+	lh_tbb_spin_rw_mutex
 
 ifeq ($(TARGET_ARCH),aarch64)
 	TEST_TARGETS+=lh_hybrid_spinlock \
@@ -46,6 +47,9 @@ lh_queued_spinlock: ../../ext/linux/queued_spinlock.h include/atomics.h ../../ex
 
 lh_jvm_objectmonitor: ../../ext/jvm/jvm_objectmonitor.h include/atomics.h src/lockhammer.c
 	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+
+lh_tbb_spin_rw_mutex: ../../ext/tbb/tbb_spin_rw_mutex.h ../../ext/tbb/include/tbb.h include/atomics.h src/lockhammer.c
+	${CC} ${CFLAGS} -DNDEBUG -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
 
 clean:
 	rm -f build/lh_*

--- a/benchmarks/lockhammer/include/atomics.h
+++ b/benchmarks/lockhammer/include/atomics.h
@@ -81,6 +81,44 @@ static inline void prefetch64 (unsigned long *ptr) {
 #endif
 }
 
+static inline unsigned long fetchadd64_acquire_release (unsigned long *ptr, unsigned long val) {
+#if defined(__x86_64__)
+	asm volatile ("lock xaddq %q0, %1\n"
+		      : "+r" (val), "+m" (*(ptr))
+		      : : "memory", "cc");
+#elif defined(__aarch64__)
+#if defined(USE_LSE)
+	unsigned long old;
+
+	asm volatile(
+	"	ldaddal	%[val], %[old], %[ptr]\n"
+	: [old] "=&r" (old), [ptr] "+Q" (*(unsigned long *)ptr)
+	: [val] "r" (val)
+	: );
+
+	val = old;
+#else
+	unsigned long tmp, old, newval;
+
+	asm volatile(
+	"1:	ldaxr	%[old], %[ptr]\n"
+	"	add	%[newval], %[old], %[val]\n"
+	"	stlxr	%w[tmp], %[newval], %[ptr]\n"
+	"	cbnz	%w[tmp], 1b\n"
+	: [tmp] "=&r" (tmp), [old] "=&r" (old), [newval] "=&r" (newval),
+	  [ptr] "+Q" (*(unsigned long *)ptr)
+	: [val] "Lr" (val)
+	: );
+
+	val = old;
+#endif
+#else
+	/* TODO: builtin atomic call */
+#endif
+
+	return val;
+}
+
 static inline unsigned long fetchadd64_acquire (unsigned long *ptr, unsigned long val) {
 #if defined(__x86_64__)
 	asm volatile ("lock xaddq %q0, %1\n"

--- a/benchmarks/lockhammer/scripts/runall.sh
+++ b/benchmarks/lockhammer/scripts/runall.sh
@@ -49,3 +49,5 @@
 ./sweep.sh jvm_objectmonitor 1000 5000 > jvm_objectmonitor_1000_5000_$HOSTNAME.csv
 ./sweep.sh swap_mutex 0 0 > swap_mutex_0_0_$HOSTNAME.csv
 ./sweep.sh swap_mutex 1000 5000 > swap_mutex_1000_5000_$HOSTNAME.csv
+./sweep.sh spin_rw_mutex 0 0 > spin_rw_mutex_0_0_$HOSTNAME.csv
+./sweep.sh spin_rw_mutex 1000 5000 > spin_rw_mutex_1000_5000_$HOSTNAME.csv

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -40,6 +40,7 @@
 #include <time.h>
 #include <string.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #include "lockhammer.h"
 

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
         }
     }
 
-    parse_test_args(args, argc - optind, &argv[optind]);
+    parse_test_args(args, argc, argv);
 
     pthread_t hmr_threads[args.nthrds];
     pthread_attr_t hmr_attr;

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
                 args.nthrds = optval;
             }
             else {
-                fprintf(stderr, "WARNING: limiting thread count to online cores (%d).\n", num_cores);
+                fprintf(stderr, "WARNING: limiting thread count to online cores (%ld).\n", num_cores);
             }
             break;
           case 'a':
@@ -220,13 +220,15 @@ int main(int argc, char** argv)
            ((double) sched_elapsed)/ ((double) result),
            ((double) real_elapsed) / ((double) result),
            avg_lock_depth);
+
+    return 0;
 }
 
 void* hmr(void *ptr)
 {
     unsigned long nlocks = 0;
     thread_args *x = (thread_args*)ptr;
-    int rval;
+
     unsigned long *lock = x->lock;
     unsigned long target_locks = x->iter;
     unsigned long ncores = x->ncores;

--- a/ext/tbb/include/tbb.h
+++ b/ext/tbb/include/tbb.h
@@ -1,0 +1,302 @@
+/*
+    Copyright (c) 2005-2018 Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+/*
+ * Based on: 
+ *
+ *      project: github.com/01org/tbb, files:
+ *      tbb/include/tbb/machine/gcc_generic.h,
+ *      tbb/inclide/tbb/machine/linux-intel64.h
+ *
+ * __TBB mappings:
+ *
+ *      Only added logic that is needed for spin_rw_mutex - only support for
+ *      64b wide data (wordsize == 8) and Linux
+ *
+ *      for Aarch64: default is GCC built-ins (based on gcc version),
+ *      alternative: lockhammer local atomics via USE_LOCAL, with or w/o USE_LSE
+ *
+ *      for x86-64: default is lockhammer local atomics (which should be same
+ *      as machine/linux_intel64.h), aternative: GCC built-ins via
+ *      USE_GCC_BUILTINS (based on gcc version)
+ *
+ * For both ISAs, USE_LOCAL has higher priority over USE_GCC_BUILTINS if used
+ * together.
+ */
+
+
+#ifndef __TBB_H
+#define __TBB_H
+
+#define _GNU_SOURCE
+
+#include "atomics.h"
+
+/* Non default configurations */
+// #define USE_LOCAL
+// #define USE_LSE
+// #define USE_GCC_BUILTINS
+
+
+#ifndef NDEBUG
+#pragma message("Using debug build!!")
+#define DBG(fmt,...) \
+    do { fprintf(stderr, "tbb>%s:%d " fmt, \
+        __func__, __LINE__, ##__VA_ARGS__); } while (0);
+
+#define __TBB_ASSERT(b, msg) \
+    do { if (!(b)) { DBG("Assert: %s\n", msg); exit (1); } } while(0);
+
+#else  /* NDEBUG */
+
+#define DBG(fmt, ...) do {} while (0);
+#define __TBB_ASSERT(b, msg) do { } while(0);
+
+#endif  /* NDEBUG */
+
+/*
+ * spin; do not yield
+ */
+static inline void machine_pause (int32_t delay) {
+    while(delay>0) {
+#if defined(__x86_64__)
+        asm volatile ("pause" : : : "memory" );
+#elif defined(__aarch64__)
+        asm volatile ("yield" : : : "memory" );
+#endif  /* ARCH */
+        delay--;
+    }
+}
+
+#if defined(USE_LOCAL) || (defined(__x86_64__) && !defined(USE_GCC_BUILTINS))
+#ifndef NDEBUG
+#pragma message("Using lockhammer atomics library!!")
+#endif  /* NDEBUG */
+
+/*
+ * this really needs to be fetchadd64_release, however we want to be same as
+ * how intel-tbb uses gcc built ins
+ *
+ * The atomics.h is aware of USE_LSE configuration
+ * So no need to do anything here.
+ */
+#define __TBB_machine_cmpswp8(P,V,C)        cas64_acquire_release(P,V,C)
+#define __TBB_machine_fetchadd8(P,V)        fetchadd64_acquire_release(P,V)
+#define __TBB_machine_fetchadd8release(P,V) fetchadd64_acquire_release(P,V)
+
+static inline void __TBB_machine_or(volatile void* operand, uint64_t addend) {
+#if defined(__x86_64__)
+    asm volatile(
+            "lock\norq %1,%0"
+            : "=m"(*(volatile uint64_t*)operand)
+            : "r"(addend), "m"(*(volatile uint64_t*)operand)
+            : "memory");
+#elif defined(__aarch64__)
+#ifndef USE_LSE
+    unsigned long old, newval, tmp;
+    asm volatile(
+            "1: ldaxr  %[old], %[ptr]\n"
+            "   orr    %[newval], %[old], %[val]\n"
+            "   stlxr  %w[tmp], %[newval], %[ptr]\n"
+            "   cbnz   %w[tmp], 1b\n"
+            : [tmp] "=&r" (tmp), [old] "=&r" (old), [newval] "=&r" (newval),
+              [ptr] "+Q" (*(unsigned long *)operand)
+            : [val] "Lr" (addend)
+            : );
+#else  /* USE_LSE */
+    // clobbering addend - to match gcc
+    asm volatile(
+    "ldsetal   %[val], %[val], %[ptr]\n"
+    : [val] "+&r" (addend), [ptr] "+Q" (*(unsigned long *)operand)
+    : );
+#endif  /* USE_LSE */
+#else
+    for(;;) {
+        uintptr_t tmp = *(volatile uintptr_t *)operand;
+        uintptr_t result = __TBB_machine_cmpswp8(operand, tmp|addend, tmp);
+        if( result==tmp ) break;
+    }
+#endif  /* ARCH */
+}
+
+static inline void __TBB_machine_and(volatile void* operand, uint64_t addend) {
+#if defined(__x86_64__)
+    asm volatile(
+            "lock\nandq %1,%0"
+            : "=m"(*(volatile uint64_t*)operand)
+            : "r"(addend), "m"(*(volatile uint64_t*)operand)
+            : "memory");
+#elif defined(__aarch64__)
+#ifndef USE_LSE
+    unsigned long old, newval, tmp;
+    asm volatile(
+            "1: ldaxr   %[old], %[ptr]\n"
+            "   and     %[newval], %[old], %[val]\n"
+            "   stlxr   %w[tmp], %[newval], %[ptr]\n"
+            "   cbnz    %w[tmp], 1b\n"
+            : [tmp] "=&r" (tmp), [old] "=&r" (old), [newval] "=&r" (newval),
+              [ptr] "+Q" (*(unsigned long *)operand)
+            : [val] "Lr" (addend)
+            : );
+#else  /* USE_LSE */
+    // clobbering addend - to match gcc
+    asm volatile(
+        "mvn %[val], %[val]\n"
+        "ldclral   %[val], %[val], %[ptr]\n"
+    : [val] "+&r" (addend), [ptr] "+Q" (*(unsigned long *)operand)
+    : );
+#endif  /* USE_LSE */
+#else
+    for(;;) {
+        uintptr_t tmp = *(volatile uintptr_t *)operand;
+        uintptr_t result = __TBB_machine_cmpswp8(operand, tmp&addend, tmp);
+        if( result==tmp ) break;
+    }
+#endif  /* ARCH */
+}
+
+#else  /* GCC Built-ins */
+
+#define __GCC_VERSION \
+    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#if __GCC_VERSION < 40700 /* use __sync* built-ins */
+#ifndef NDEBUG
+#pragma message("Using old gcc (<4.7.0) built-ins!!")
+#endif  /* NDEBUG */
+
+#define __TBB_MACHINE_DEFINE_ATOMICS(S,T)                                      \
+inline T __TBB_machine_cmpswp##S( volatile void *ptr, T value, T comparand ) { \
+    return __sync_val_compare_and_swap((volatile T *)ptr,comparand,value);     \
+}                                                                              \
+inline T __TBB_machine_fetchadd##S( volatile void *ptr, T value ) {            \
+    return __sync_fetch_and_add((volatile T *)ptr,value);                      \
+}
+
+static inline void __TBB_machine_or( volatile void *ptr, uintptr_t addend ) {
+    __sync_fetch_and_or((volatile uintptr_t *)ptr,addend);
+}
+
+static inline void __TBB_machine_and( volatile void *ptr, uintptr_t addend ) {
+    __sync_fetch_and_and((volatile uintptr_t *)ptr,addend);
+}
+
+#else  /* __GCC_VERSION >= 40700; use __atomic* built-ins */
+#ifndef NDEBUG
+#pragma message("Using new gcc (>=4.7.0) built-ins!!")
+#endif  /* NDEBUG */
+
+#define __TBB_MACHINE_DEFINE_ATOMICS(S,T)                                      \
+inline T __TBB_machine_cmpswp##S( volatile void *ptr, T value, T comparand ) { \
+    (void)__atomic_compare_exchange_n((volatile T *)ptr, &comparand, value,    \
+                                      0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);  \
+    return comparand;                                                          \
+}                                                                              \
+inline T __TBB_machine_fetchadd##S( volatile void *ptr, T value ) {            \
+    return __atomic_fetch_add((volatile T *)ptr, value, __ATOMIC_SEQ_CST);     \
+}
+
+static inline void __TBB_machine_or( volatile void *ptr, uintptr_t addend ) {
+    __atomic_fetch_or((volatile uintptr_t *)ptr,addend,__ATOMIC_SEQ_CST);
+}
+
+static inline void __TBB_machine_and( volatile void *ptr, uintptr_t addend ) {
+    __atomic_fetch_and((volatile uintptr_t *)ptr,addend,__ATOMIC_SEQ_CST);
+}
+
+#endif  /* __GCC_VERSION */
+
+/* only intptr_t for now */
+__TBB_MACHINE_DEFINE_ATOMICS(8, intptr_t)
+
+/*
+ * func: fetchaddNrelese
+ * Scope for optimization on AArch64 side: we may not need acquire semantics?
+ */
+#define  __TBB_machine_fetchadd8release(P,V)  __TBB_machine_fetchadd8(P,V)
+
+#endif  /* USE_LOCAL, __x86_64__ && !USE_GCC_BUILTINS */
+
+
+/*
+ * Top level abstraction
+ */
+#define __TBB_machine_pause(C)              machine_pause(C)
+#define __TBB_Yield()                       sched_yield()
+#define __TBB_Pause(C)                      __TBB_machine_pause(C)
+#define __TBB_CompareAndSwapW(P,V,C)        __TBB_machine_cmpswp8(P,V,C)
+#define __TBB_FetchAndAddW(P,V)             __TBB_machine_fetchadd8(P,V)
+#define __TBB_FetchAndAddWrelease(P,V)      __TBB_machine_fetchadd8release(P,V)
+#define __TBB_AtomicOR(P,V)                 __TBB_machine_or(P,V)
+#define __TBB_AtomicAND(P,V)                __TBB_machine_and(P,V)
+
+/* TBB helper routines */
+
+/*
+ * From: class atomic_backoff : no_copy
+ *
+ * //! Class that implements exponential backoff.
+ * 16 is approximately how many 'pause' x86 instruction takes for
+ * their context switch, not changing it for now, do we need to change?
+ */
+#define LOOPS_BEFORE_YIELD 16
+
+static inline void atomic_backoff__pause(int32_t *count) {
+    if( *count<=LOOPS_BEFORE_YIELD ) {
+        __TBB_Pause(*count);
+        // Pause twice as long the next time.
+        *count*=2;
+    } else {
+        // Pause is so long that we might as well yield CPU to scheduler.
+        __TBB_Yield();
+    }
+}
+
+/*
+ * Generic versions of helper functions if not defined by now
+ */
+#ifndef __TBB_AtomicOR
+#ifndef NDEBUG
+#pragma message("Using backoff based AtomicOR!!")
+#endif  /* NDEBUG */
+static inline void __TBB_AtomicOR(void* operand, uintmax_t addend) {
+    int32_t count;
+    for(count = 1;;atomic_backoff__pause(&count)) {
+        uintptr_t tmp = *(volatile uintptr_t *)operand;
+        uintptr_t result = __TBB_CompareAndSwapW(operand, tmp|addend, tmp);
+        if( result==tmp ) break;
+    }
+}
+#endif  /* __TBB_AtomicOR */
+
+#ifndef __TBB_AtomicAND
+#ifndef NDEBUG
+#pragma message("Using backoff based AtomicAND!!")
+#endif  /* NDEBUG */
+static inline void __TBB_AtomicAND(void* operand, uintptr_t addend) {
+    int32_t count;
+    for(count = 1;;atomic_backoff__pause(&count)) {
+        uintptr_t tmp = *(volatile uintptr_t *)operand;
+        uintptr_t result = __TBB_CompareAndSwapW(operand, tmp&addend, tmp);
+        if( result==tmp ) break;
+    }
+}
+#endif  /* __TBB_AtomicAND */
+#endif  /* __TBB_H */

--- a/ext/tbb/include/tbb.h
+++ b/ext/tbb/include/tbb.h
@@ -128,6 +128,7 @@ static inline void __TBB_machine_or(volatile void* operand, uint64_t addend) {
     : );
 #endif  /* USE_LSE */
 #else
+    /* Arch independent implementation */
     for(;;) {
         uintptr_t tmp = *(volatile uintptr_t *)operand;
         uintptr_t result = __TBB_machine_cmpswp8(operand, tmp|addend, tmp);
@@ -164,6 +165,7 @@ static inline void __TBB_machine_and(volatile void* operand, uint64_t addend) {
     : );
 #endif  /* USE_LSE */
 #else
+    /* Arch independent implementation */
     for(;;) {
         uintptr_t tmp = *(volatile uintptr_t *)operand;
         uintptr_t result = __TBB_machine_cmpswp8(operand, tmp&addend, tmp);

--- a/ext/tbb/tbb_spin_rw_mutex.h
+++ b/ext/tbb/tbb_spin_rw_mutex.h
@@ -22,6 +22,7 @@
  *  Based on:
  *
  *      Project: github.com/01org/tbb, File: tbb/include/tbb/spin_rw_mutex.h
+ *      Tag: 2018_U3-0-g633b01a
  *
  *  Description:
  *

--- a/ext/tbb/tbb_spin_rw_mutex.h
+++ b/ext/tbb/tbb_spin_rw_mutex.h
@@ -1,0 +1,291 @@
+/*
+    Copyright (c) 2005-2018 Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+/*
+ *  Based on:
+ *
+ *      Project: github.com/01org/tbb, File: tbb/include/tbb/spin_rw_mutex.h
+ *
+ *  Description:
+ *
+ *      This file implements 'Fast, unfair, spinning reader-writer lock with
+ *      back-off and writer-preference'. The algorithm is based on
+ *      'spin_rw_mutex' from Intel TBB library.
+ *
+ *  Internals:
+ *
+ *      - Cutting through layers of abstractions in the original source code, I
+ *      made things not as clean as it was. However, during the porting
+ *      process, I tried to keep things as similar as possible to the setup in
+ *      the Intel TBB library. I ported only required things for this
+ *      synchronization scheme to work.
+ *
+ *      - The lockhammer/tbb.h file tries to provide similar __TBB level
+ *      abstractions as tbb/include/tbb/tbb_machine.h but it is primitive and
+ *      has only definitions needed for this particular scheme.
+ *
+ *      - Underlying atomics primitives are from GCC built-ins as configured in
+ *      gcc_generic.h file in tbb project for Aarch64. For x86-64 they are
+ *      derived from tbb/include/tbb/machine/linux_intel64.h file. The expected
+ *      ISA is either x86-64 (no TSX) or Aarch64, 64bit only and the OS is
+ *      Linux (for sched_yield).
+ *
+ *      - For Aarch64, TBB is using GCC generic atomic built-ins as a base. It
+ *      does not assume anything about memory model or ISA. So, the
+ *      implementation could be suboptimal. We inherit those traits here as
+ *      well.
+ *
+ *      - In lockhammer/tbb.h, there are several macros which allow you to
+ *      select which variant of atomics to use. For Aarch64, the default is GCC
+ *      built-ins, and for x86-64, the defaults are supplied by the file. These
+ *      default choices are similar to the TBB setup.
+ *
+ *  Changes from TBB:
+ *
+ *      - One main change is in the definition of 'machine_pause()'. Here, it
+ *      would first spin and then sched_yield() unlike the default in TBB where
+ *      it would sched_yield() immediately (at least for Aarch64).
+ *
+ *      - Does not implement upgrade() or downgrade() methods
+ *
+ *      - Not using C++ because it is difficult given this benchmark framework
+ *      as well as the other complexities which comes from pulling out a set of
+ *      classes from a class tree in tbb.
+ *
+ *  Workings:
+ *
+ *      This implements classical reader-writer lock. Which means a lock can be
+ *      held by a single writer or a group of readers at the same time but not
+ *      both.
+ *
+ *      From tbb docs: " Mutual exclusion is necessary when at least one thread
+ *      writes to a shared variable. But it does no harm to permit multiple
+ *      readers into a protected region. The reader-writer variants of the
+ *      mutexes [...] enable multiple readers by distinguishing reader locks
+ *      from writer locks. There can be more than one reader lock on a given
+ *      mutex."
+ *
+ *      When a writer first tries to acquire the lock, if there are no readers
+ *      already holding the lock, it will acquire it else in the presence of
+ *      readers it will set a writer pending bit if not set. If this bit is
+ *      already set or after setting the bit the writer will start backing off
+ *      eventually yielding the CPU until obtaining the lock.
+ *
+ *      In case of readers, more than one of them can go in the exclusive
+ *      section simultaneously. If no writer is holding the lock or no pending
+ *      writers, a reader even in presence of other reader can acquire the lock.
+ *      It will back off and eventually yield the CPU when writer is holding a
+ *      lock until the lock becomes available again.
+ *
+ *  Readers/Writers ratio (-r) and Pure readers (-m):
+ *
+ *      - 'rw_mask' variable defines the ratio between readers and writers per
+ *      thread. It is controlled using log2_ratio variable, cmdline args -r.
+ *
+ *      - Given the ratio, a thread will perform that many 'read_acquire' and
+ *      'read_release' calls and then it will do one 'write_acquire' and
+ *      'write_release'. And then if more work to be done, repeat.
+ *
+ *      For a thread:
+ *
+ *      num readers
+ *      ----------- = 2^(log2_ratio) - 1;
+ *      num writers
+ *
+ *       > log2_ratio of  0 means all writers
+ *       > log2_ratio of ~0 means all readers
+ *       > default log2_ratio is 6 e.g 63 reads per write.
+ *
+ *      - Pure readers are CPUs which will never perform a write acq/rel. The
+ *        cmdline arg is a bit mask e.g. 0x8 will make 4th cpu (cpu id: 0x3)
+ *        a pure reader. Default is 0x0 e.g. no pure readers.
+ *
+ */
+
+#ifndef __TBB_spin_mutex_H
+#define __TBB_spin_mutex_H
+
+#define initialize_lock(lock, threads) tbb_init_locks(lock, threads)
+#define parse_test_args(args, argc, argv) tbb_parse_args(args, argc, argv)
+
+#include "tbb.h"
+
+#define WRITER          1
+#define WRITER_PENDING  2
+#define READERS         ~(WRITER | WRITER_PENDING)
+#define ONE_READER      4
+#define BUSY            (WRITER | READERS)
+
+unsigned long log2_ratio = 0;
+unsigned long rw_mask = 0;
+unsigned long reader_cpu_mask = 0;
+
+typedef struct {
+    unsigned long c;
+    uint8_t pure_reader;
+} __attribute__((aligned(64))) rw_count_t;
+
+rw_count_t *rw_counts;
+
+inline uint8_t is_writer(unsigned long i, uint8_t val) {
+    if (rw_counts[i].pure_reader)
+        return 0;
+    rw_counts[i].c += val;
+    return !(rw_counts[i].c & rw_mask);
+}
+
+void tbb_print_usage() {
+    fprintf(stderr, " tbb_spin_rw_mutex\n");
+    fprintf(stderr, "\t[-h print this msg]\n");
+    fprintf(stderr, "\t[-r reader/writer log ratio, default: 6 (2^(6)-1 readers per writer)]\n");
+    fprintf(stderr, "\t[-m pure reader cpu mask, default: 0x0 (no pure readers)]\n");
+}
+
+void tbb_parse_args(test_args unused, int argc, char** argv) {
+    int i = 0;
+
+    log2_ratio = 6;
+    reader_cpu_mask = 0x0;
+
+    while ((i = getopt(argc, argv, "hr:m:")) != -1)
+    {
+        switch (i) {
+          case 'r':
+            log2_ratio = strtoul(optarg, (char **) NULL, 10);
+            if (log2_ratio >= 64) {
+                fprintf(stderr, "tbb_spin_rw_mutex: -r can not be >= 64\n");
+                exit(1);
+            }
+            break;
+          case 'm':
+            if (!strncmp(optarg, "0x", 2))
+                reader_cpu_mask = strtoul(optarg, (char **) NULL, 16);
+            else
+                reader_cpu_mask = strtoul(optarg, (char **) NULL, 10);
+            if (errno == ERANGE) {
+                fprintf(stderr,
+                        "tbb_spin_rw_mutex: -m value unsuitable for 'unsigned long'\n");
+                exit (1);
+            }
+            break;
+          case 'h':
+            tbb_print_usage();
+            exit(0);
+          case '?':
+          default:
+            tbb_print_usage();
+            exit(3);
+        }
+        if (errno == EINVAL) {
+            tbb_print_usage();
+            exit(2);
+        }
+    }
+}
+
+void tbb_init_locks (unsigned long *lock, unsigned long cores) {
+    unsigned i;
+    rw_mask = ((1UL<<log2_ratio)-1);
+    rw_counts = (rw_count_t*) malloc(cores * sizeof(rw_count_t));
+
+    DBG("On each thread, for every %lu readers there will be 1 writer\n", rw_mask);
+    DBG("CPU mask 0x%lx will be readers\n", reader_cpu_mask);
+
+    for (i=0; i < cores; ++i) {
+        rw_counts[i].pure_reader = (reader_cpu_mask & (1UL << i)) ? 1 : 0;
+        DBG("\t CPU[%u], a pure reader? %u\n", i, rw_counts[i].pure_reader);
+    }
+}
+
+//! State of lock
+/** Bit 0 = writer is holding lock
+    Bit 1 = request by a writer to acquire lock (hint to readers to wait)
+    Bit 2..N = number of readers holding lock */
+typedef intptr_t state_t;
+state_t state;
+
+static inline state_t CAS(state_t *s, state_t new_val, state_t old_val) {
+   return (state_t)__TBB_CompareAndSwapW(s, new_val, old_val);
+}
+
+static inline void internal_acquire_writer(unsigned long t) {
+    int32_t count;
+    DBG("init [%ld]: 0x%lx\n", t, state);
+    for(count = 1;;atomic_backoff__pause(&count)) {
+        state_t s = (volatile state_t) state;
+        if( !(s & BUSY) ) { // no readers, no writers
+            if( CAS(&state, WRITER, state)==s ) {
+                break; // successfully stored writer flag
+            }
+            count = 1; // we could be very close to complete op.
+        } else if( !(s & WRITER_PENDING) ) { // no pending writers
+            __TBB_AtomicOR(&state, WRITER_PENDING);
+        }
+    }
+    DBG("final [%ld]: 0x%lx\n", t, state);
+}
+
+static void internal_release_writer(unsigned long t) {
+    DBG("init [%ld]: 0x%lx\n", t, state);
+    __TBB_AtomicAND( &state, READERS );
+    DBG("final [%ld]: 0x%lx\n", t, state);
+}
+
+static inline void internal_acquire_reader(unsigned long t) {
+    int32_t count;
+    DBG("init [%ld]: 0x%lx\n", t, state);
+    for(count = 1;;atomic_backoff__pause(&count)) {
+        state_t s = (volatile state_t) state; // ensure reloading
+        if( !(s & (WRITER|WRITER_PENDING)) ) { // no writer or write requests
+            state_t t = \
+                (state_t)__TBB_FetchAndAddW( &state, (state_t) ONE_READER );
+            if( !( t&WRITER ))
+                break; // successfully stored increased number of readers
+            // writer got there first, undo the increment
+            __TBB_FetchAndAddW( &state, -(state_t)ONE_READER );
+        }
+    }
+    __TBB_ASSERT( state & READERS, "invalid state of a read lock: no readers" );
+    DBG("final [%ld]: 0x%lx\n", t, state);
+}
+
+static void internal_release_reader(unsigned long t) {
+    DBG("init [%ld]: 0x%lx\n", t, state);
+    __TBB_FetchAndAddWrelease( &state,-(state_t)ONE_READER);
+    DBG("final [%ld]: 0x%lx\n", t, state);
+}
+
+static inline unsigned long
+lock_acquire (unsigned long *lock, unsigned long threadnum) {
+    (is_writer(threadnum,1))
+        ? internal_acquire_writer(threadnum)
+        : internal_acquire_reader(threadnum);
+    /* average depth will always = 1 */
+    return 1;
+}
+
+static inline void
+lock_release (unsigned long *lock, unsigned long threadnum) {
+    (is_writer(threadnum,0))
+        ? internal_release_writer(threadnum)
+        : internal_release_reader(threadnum);
+    return;
+}
+#endif /* __TBB_spin_mutex_H */


### PR DESCRIPTION
Add the tbb_spin_rw_mutex test extracted from intel TBB library
(https://www.threadingbuildingblocks.org).  This test is unique
in that it includes the ability to specify different numbers of
readers and writers during test execution.  Reader/writer ratio
and pure reader mask can be set via the test-specific arguments
'-r' and '-m', respectively, after '--' on the command line.

Change-Id: Ie6b4e589c3728c6f308cf73a4734136ba6baf463
Signed-off-by: Lucas Crowthers <lucasc.qdt@qualcommdatacenter.com>