### PR TITLE
Per-thread realtime average acquire time metric

### DIFF
--- a/benchmarks/lockhammer/include/lockhammer.h
+++ b/benchmarks/lockhammer/include/lockhammer.h
@@ -39,6 +39,7 @@ struct thread_args {
     unsigned long *lock;
     unsigned long *rst;
     unsigned long *nsec;
+    unsigned long *real_nsec;
     unsigned long *depth;
     unsigned long *nstart;
     unsigned long hold, post;


### PR DESCRIPTION
Add a new metric which measures the average amount of real time between acquires on each core.  This differs from the existing metrics which either measure the real time between acquires on any core on the cpu (total SoC throughput) or the scheduled time between acquires on a each core (which may appear artificially small for locking algorithms which sleep waiting threads).

Fixes #12 