### PR TITLE
Lockhammer: Document version origins

### DIFF
--- a/ext/jvm/jvm_objectmonitor.h
+++ b/ext/jvm/jvm_objectmonitor.h
@@ -36,6 +36,8 @@
 /*
  * jvm_objectmonitor.h: A model of the OpenJDK ObjectMonitor class.
  *
+ * based on OpenJDK9
+ *
  * What Is It?
  *   In the JVM, the ObjectMonitor class is responsible for
  *   regulating which threads get access to methods and blocks

--- a/ext/linux/queued_spinlock.h
+++ b/ext/linux/queued_spinlock.h
@@ -16,6 +16,8 @@
  * Authors: Waiman Long <waiman.long@hp.com>
  */
 
+/* Based on Cavuim Queued Spinlock patches applied to Linux 4.13 */
+
 #define initialize_lock(lock, threads) mcs_init_locks(lock, threads)
 
 #include "atomics.h"

--- a/ext/linux/ticket_spinlock.h
+++ b/ext/linux/ticket_spinlock.h
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* Based on Linux 4.13 */
 
 #include "atomics.h"
 

--- a/ext/mysql/cas_event_mutex.h
+++ b/ext/mysql/cas_event_mutex.h
@@ -17,6 +17,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 *****************************************************************************/
 
+/* Based on MySQL 5.7 */
+
 #define initialize_lock(lock, threads) event_mutex_init(lock, threads)
 
 #include "atomics.h"

--- a/ext/mysql/event_mutex.h
+++ b/ext/mysql/event_mutex.h
@@ -17,6 +17,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 *****************************************************************************/
 
+/* Based on MySQL 5.7 */
+
 #define initialize_lock(lock, threads) event_mutex_init(lock, threads)
 
 #include "atomics.h"


### PR DESCRIPTION
Add comments to each of the externally-derived algorithms in the suite indicating the version they were ported from.

Fixes #6 