### PR TITLE
Lockhammer: Add a safe mode command-line option

### DIFF
--- a/benchmarks/lockhammer/README.rst
+++ b/benchmarks/lockhammer/README.rst
@@ -37,3 +37,14 @@ as possible).
 
 Detailed information about each run is printed to stderr while a CSV summary
 is printed to stdout.
+
+Usage
+=====
+
+The build system will generate a separate lockhammer binary for each test with
+the format lh_[testname]. Each lockhammer binary accepts the following options:
+        [-t threads]    Number of threads to exercise, default online cores
+        [-a acquires]   Number of acquisitions per thread, default 50000
+        [-c critical]   Critical section in loop iterations, default 0
+        [-p parallel]   Parallelizable section in loop iterations, default 0
+        [-s]            Run in safe mode, default no

--- a/benchmarks/lockhammer/include/lockhammer.h
+++ b/benchmarks/lockhammer/include/lockhammer.h
@@ -53,6 +53,7 @@ struct test_args {
     unsigned long ncrit;
     unsigned long nparallel;
     unsigned long ileave;
+    unsigned char safemode;
 };
 typedef struct test_args test_args;
 


### PR DESCRIPTION
Normal invocation of lockhammer runs with all threads pinned to
specific cores in the FIFO scheduler with threads synchronized to
only start testing after all threads have successfully been
scheduled.  This entails many pitfalls including necessitating
running as root and the possiblity for poor system responsiveness
or even hangs.  Add a safe mode option which avoids all of these
at the cost of significantly less accurate performance measurment.

Change-Id: Iecde0a60ca5354d2efdb9e664d161ecddded63f8
Signed-off-by: Lucas Crowthers <lucasc.qdt@qualcommdatacenter.com>