### PR TITLE
Jenkins: Fixed executing test scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ node {
             def scr = new File("${it}/scripts/")
             scr.traverse(type: FILES, filter: ~/.*\/test[^\/]*/) {
                 try {
-                    sh it
+                    sh "${it}"
                 }
                 catch (exc) {
                     fails.add(it.toString().substring(env.WORKSPACE.length()))


### PR DESCRIPTION
"sh it" ran "it" as a java File object instead of passing the string to
a shell. This commit fixes that.