### PR TITLE
Add automatic lstopo core order generation to lockhammer sweeptest

### DIFF
--- a/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
+++ b/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
@@ -67,7 +67,7 @@ sweeptest:
         - lh_ticket_spinlock
     cmd_aarch64: [lh_hybrid_spinlock, lh_hybrid_spinlock_fastdequeue]
     cmd_x86_64:
-    repeat: 7
+    repeat: 9
     sweepargu: t
     argumax: 0
     skipsince: 48

--- a/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
+++ b/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
@@ -67,7 +67,7 @@ sweeptest:
         - lh_ticket_spinlock
     cmd_aarch64: [lh_hybrid_spinlock, lh_hybrid_spinlock_fastdequeue]
     cmd_x86_64:
-    repeat: 1
+    repeat: 7
     sweepargu: t
     argumax: 0
     skipsince: 48

--- a/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
+++ b/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
@@ -67,7 +67,7 @@ sweeptest:
         - lh_ticket_spinlock
     cmd_aarch64: [lh_hybrid_spinlock, lh_hybrid_spinlock_fastdequeue]
     cmd_x86_64:
-    repeat: 9
+    repeat: 1
     sweepargu: t
     argumax: 0
     skipsince: 48
@@ -76,15 +76,19 @@ sweeptest:
         - a: 5000
           c: 0ns
           p: 0ns
+          o: lstopo
         - a: 5000
           c: 1000ns
           p: 0ns
+          o: lstopo
         - a: 5000
           c: 200ns
           p: 1000ns
+          o: lstopo
         - a: 5000
           c: 1000ns
           p: 5000ns
+          o: lstopo
 
 ## Unittest Settings
 #
@@ -123,6 +127,7 @@ unittest:
           a: 100
           c: 50ns
           p: 0ns
+          o: lstopo
           extra:
               u: 10
               s: 2
@@ -132,6 +137,8 @@ unittest:
           a: 100
           c: 50ns
           p: 0ns
+          i: 2
+          o: '0,1,2,3'
           extra:
               r: 4
               m: 1

--- a/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
+++ b/benchmarks/lockhammer/scripts/lh_test_cfg.yaml
@@ -137,7 +137,7 @@ unittest:
           a: 100
           c: 50ns
           p: 0ns
-          i: 2
+          i: 1
           o: '0,1,2,3'
           extra:
               r: 4


### PR DESCRIPTION
We parse hwloc lstopo output in test_lockhammer.py and channel them to lockhammer workload via new -o option.

Therefore we solved the thread pinning order problem and sweep test can now choose the corresponding cluster-core/hyper-thread pair correctly.