### PR TITLE
Relaxed checking on arbitrary pinning order

### DIFF
--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -182,9 +182,9 @@ int main(int argc, char** argv)
             for (int i = 0; i < num_cores && csv != NULL; ++i)
             {
                 optval = strtol(csv, (char **) NULL, 10);
-                if (optval >= 0 && optval < num_cores) {
-                    args.pinorder[i] = optval;
-                } else {
+                /* Some Arm systems may have core number larger than total cores number */
+                args.pinorder[i] = optval;
+                if (optval < 0 || optval > num_cores) {
                     fprintf(stderr, "WARNING: core number %ld is out of range.\n", optval);
                 }
                 csv = strtok(NULL, ",");


### PR DESCRIPTION
If logical core id is higher than total core number, we should simply use this number without ignoring it. A warning message will be printed though.

Some platforms may have this topology.