### PR TITLE
Lockhammer: make -t 0 parameter like -t max_num_cores parameter

### DIFF
--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -109,6 +109,9 @@ int main(int argc, char** argv)
                 fprintf(stderr, "ERROR: thread count must be positive.\n");
                 return 1;
             }
+            else if (optval == 0) {
+                optval = num_cores;
+            }
             else if (optval <= num_cores) {
                 args.nthrds = optval;
             }


### PR DESCRIPTION
Currently -t==0 will be treated like 0 thread case, which has invalid results. We'd better treat -t == 0 as default -t, and use max threads instead of 0 thread. Therefore test_lockhammer.py calc_sweep_list() function can be easier because every parameter can start with zero now.