### PR TITLE
Change default sweeptest to safe mode

### DIFF
--- a/benchmarks/lockhammer/scripts/lh_sweeptest_cfg.yaml
+++ b/benchmarks/lockhammer/scripts/lh_sweeptest_cfg.yaml
@@ -52,7 +52,7 @@ globalcfg:
 ##
 sweeptest:
     enabled: True
-    safemode: False
+    safemode: True
     cmd:
         - lh_cas_event_mutex
         - lh_cas_lockref

--- a/benchmarks/lockhammer/scripts/test_lockhammer.py
+++ b/benchmarks/lockhammer/scripts/test_lockhammer.py
@@ -320,7 +320,7 @@ def generate_sweeptest(className, lhCfg):
 
     execDir = default_value(globalCfg, 'execdir', os.path.join("..", "build"))
     logFile = default_value(globalCfg, 'logfile', None)
-    safeMode = default_value(sweepCfg, 'safemode', False)
+    safeMode = default_value(sweepCfg, 'safemode', True)
     repeatCnt = default_value(sweepCfg, 'repeat', 7)
     sweepArgu = default_value(sweepCfg, 'sweepargu', 't')
     arguMax = default_value(sweepCfg, 'argumax', 0)


### PR DESCRIPTION
Change default sweeptest script to safe mode, keep lockhammer test as default unsafe mode.