### PR TITLE
Fix release semantics in jvm_objectmonitor

### DIFF
--- a/ext/jvm/jvm_objectmonitor.h
+++ b/ext/jvm/jvm_objectmonitor.h
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  *
+ * Portions copyright (c) 2019, ARM Limited and Contributors. All rights
+ * reserved.
  */
 
 #ifndef JVM_OBJECT_MONITOR_H
@@ -120,9 +122,7 @@
 
 inline static void release_store_thread(volatile pthread_t* dest,
         pthread_t val) {
-    READ_MEM_BARRIER;
-    *dest = val;
-    WRITE_MEM_BARRIER;
+    __atomic_store_n(dest, val, __ATOMIC_RELEASE);
 }
 
 inline static void storeload(void) {


### PR DESCRIPTION
The existing release_store_thread does not provide release semantics.
Replace the implemtation with a store that does provide release
semantics and which allows better optimization on architectures with
dedicated store-with-release-semantics instructions.

Fixes #58

Change-Id: I3fd68689a79565b50c122ea3b964127e40c00b60
Signed-Off-By: Chase Conklin <chase.conklin@arm.com>