### PR TITLE
Fix assembler warnings in lh_cas_event_mutex

### DIFF
--- a/ext/mysql/cas_event_mutex.h
+++ b/ext/mysql/cas_event_mutex.h
@@ -2,6 +2,7 @@
 
 Copyright (c) 1994, 2017, Oracle and/or its affiliates. All Rights Reserved.
 Copyright (c) 2017, The Linux Foundation. All rights reserved.
+Copyright (c) 2019, ARM Limited and Contributors. All rights reserved.
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -84,7 +85,7 @@ void lock_signal(void)
                uint32_t exResult;
 
                __asm__ __volatile__ ("stxr %w[exResult], %[lockValue],[%[lockAddr]]"
-                                       : [exResult] "=r" (exResult)
+                                       : [exResult] "=&r" (exResult)
                                        : [lockAddr] "r" (lock), [lockValue] "r" (MUTEX_STATE_LOCKED)
                                        :"memory");
 


### PR DESCRIPTION
The AArch64 inline assembly in cas_event_mutex.h is missing an
early-clobber specifier for the status register, resulting in warnings
from GCC

  Warning: unpredictable: identical transfer and status registers
  --`stxr w0,x1,[x0]'

Fixes #60

Signed-off-by: Chase Conklin <chase.conklin@arm.com>