### PR TITLE
Fix race condition in synchronize_threads()

### DIFF
--- a/benchmarks/lockhammer/include/atomics.h
+++ b/benchmarks/lockhammer/include/atomics.h
@@ -494,8 +494,8 @@ void synchronize_threads(uint64_t *barrier, unsigned long nthrds)
     uint64_t tmp_sense = ~global_sense & SENSE_BIT_MASK;
     uint32_t local_sense = (uint32_t)(tmp_sense >> 32);
 
-    fetchadd64_acquire(barrier, 2);
-    if (*barrier == ((nthrds * 2) | global_sense)) {
+    uint64_t old_barrier = fetchadd64_acquire(barrier, 2);
+    if (old_barrier == (((nthrds - 1) * 2) | global_sense)) {
         // Make sure the store gets observed by the system. Reset count
         // to zero and flip the sense bit.
         __atomic_store_n(barrier, tmp_sense, __ATOMIC_RELEASE);


### PR DESCRIPTION
Discovered a race condition in the `synchronize_threads` thread barrier implementation in atomics.h.  Threads could race between the `fetchadd64_acquire` and the checking on the value of the barrier, which occasionally leads to deadlock.  Fix is to use the returned old value of the barrier to check if the exit condition has been reached.