### PR TITLE
osq_lock: add define to use smp_cond_load_relaxed.

### DIFF
--- a/ext/linux/include/lk_atomics.h
+++ b/ext/linux/include/lk_atomics.h
@@ -358,6 +358,20 @@ do {									\
 	}								\
 	VAL;								\
 })
+
+#define smp_cond_load_relaxed(ptr, cond_expr)				\
+({									\
+	typeof(ptr) __PTR = (ptr);					\
+	typeof(*ptr) VAL;						\
+	for (;;) {							\
+		VAL = READ_ONCE(*__PTR);				\
+		if (cond_expr)						\
+			break;						\
+		__cmpwait_relaxed(__PTR, VAL);				\
+	}								\
+	VAL;								\
+})
+
 #else
 #define __smp_store_release(p, v)					\
 do {									\
@@ -384,6 +398,19 @@ do {									\
 	barrier();						\
 	VAL;							\
 })
+
+#define smp_cond_load_relaxed(ptr, cond_expr) ({		\
+	typeof(ptr) __PTR = (ptr);				\
+	typeof(*ptr) VAL;					\
+	for (;;) {						\
+		VAL = READ_ONCE(*__PTR);			\
+		if (cond_expr)					\
+			break;					\
+		cpu_relax();					\
+	}							\
+	VAL;							\
+})
+
 #endif
 
 #define arch_mcs_spin_lock_contended(l)					\


### PR DESCRIPTION
Adds a define USE_SMP_COND_LOAD_RELAXED that enables use of
smp_cond_load_relaxed in osq_lock spin (as per v5.6 kernel).

To address issue #69.