### PR TITLE
lockhammer/prefetch64: do not dereference lock pointer

### DIFF
--- a/benchmarks/lockhammer/include/atomics.h
+++ b/benchmarks/lockhammer/include/atomics.h
@@ -95,7 +95,7 @@ static inline void prefetch64 (unsigned long *ptr) {
 #if defined(__aarch64__)
 	asm volatile("	prfm	pstl1keep, %[ptr]\n"
 	:
-	: [ptr] "Q" (*(unsigned long *)ptr));
+	: [ptr] "Q" (ptr));
 #endif
 }
 


### PR DESCRIPTION
On aarch64, prefetch64() takes a pointer to the lock, but dereferences the
pointer as the address to prefetch.  Don't do that; it causes memory accesses to
a random memory location (i.e. takes the literal lock value as the address).  
Instead, just pass the value of the pointer into the PRFM instruction.