### PR TITLE
Revert "lockhammer/prefetch64: do not dereference lock pointer"

### DIFF
--- a/benchmarks/lockhammer/include/atomics.h
+++ b/benchmarks/lockhammer/include/atomics.h
@@ -95,7 +95,7 @@ static inline void prefetch64 (unsigned long *ptr) {
 #if defined(__aarch64__)
 	asm volatile("	prfm	pstl1keep, %[ptr]\n"
 	:
-	: [ptr] "Q" (ptr));
+	: [ptr] "Q" (*(unsigned long *)ptr));
 #endif
 }
 


### PR DESCRIPTION
Reverts ARM-software/synchronization-benchmarks#71