### PR TITLE
Fix x86 clobber lists

### DIFF
--- a/benchmarks/lockhammer/include/perf_timer.h
+++ b/benchmarks/lockhammer/include/perf_timer.h
@@ -138,7 +138,8 @@ rdtscp_start(void)
             "mov %%edx, %0\n\t"
             "mov %%eax, %1\n\t":
              "=r" (tsc.hi_32),
-             "=r" (tsc.lo_32)::"%rax", "%rbx", "%rcx", "%rdx");
+             "=r" (tsc.lo_32)
+             ::"eax", "ebx", "ecx", "edx");
 
     return tsc.tsc_64;
 }
@@ -164,7 +165,8 @@ rdtscp_end(void)
             "mov %%eax, %1\n\t"
             "CPUID\n\t":
              "=r" (tsc.hi_32),
-             "=r" (tsc.lo_32)::"%rax", "%rbx", "%rcx", "%rdx");
+             "=r" (tsc.lo_32)
+             ::"eax", "ebx", "ecx", "edx");
 
     return tsc.tsc_64;
 

--- a/ext/linux/ticket_spinlock.h
+++ b/ext/linux/ticket_spinlock.h
@@ -46,7 +46,7 @@ asm volatile (
 "4:\n"
 : [lock] "+m" (*lock), [depth] "=m" (depth)
 :
-: "cc" );
+: "cc", "eax", "ecx", "edx", "ax", "cx", "dx" );
 	depth = (((depth >> 16) - (depth & 0xFFFF)) & 0xFFFF) >> 2;
 #elif defined(__aarch64__)
 	unsigned tmp, tmp2, tmp3;


### PR DESCRIPTION
Add missing registers to asm clobber lists.

lh_ticket_spinlock no longer hangs on Amazon Linux 2 (gcc 7.3.1) builds.
