### PR TITLE
Remove redundant gettime call in lockhammer.c for main thread

### DIFF
--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -386,7 +386,6 @@ void* hmr(void *ptr)
 
         /* Wait for all threads to arrive from calibrating. */ 
         synchronize_threads(&calibrate_lock, nthrds);
-        clock_gettime(CLOCK_MONOTONIC, &tv_monot_start);
     } else {
         /*
          * Non-zero core value indicates next core to pin, zero value means


### PR DESCRIPTION
Remove an unnecessary `clock_gettime` call as its called again outside the if/else block.