### PR TITLE
swap_mutex: use store release in lock_release()

### DIFF
--- a/benchmarks/lockhammer/tests/swap_mutex.h
+++ b/benchmarks/lockhammer/tests/swap_mutex.h
@@ -35,12 +35,14 @@ static inline unsigned long lock_acquire (uint64_t *lock, unsigned long threadnu
 	unsigned long val = 1;
 
 	while (val) {
-		val = swap64 (lock, 1);
+		val = swap64 (lock, 1); // uses acquire-release semantics
 	}
 
 	return 0;
 }
 
 static inline void lock_release (uint64_t *lock, unsigned long threadnum) {
-	*(volatile unsigned long *) lock = 0;
+	__atomic_store_n(lock, 0, __ATOMIC_RELEASE);
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab: */


### PR DESCRIPTION
Use store release in lock_release() to ensure it is memory ordered after lock_acquire().

Also, add vim modeline.

Change-Id: I9580d312b83ea2486dc1c45f92ef7a4b94b73afd