### PR TITLE
2025-05 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+benchmarks/lockhammer/build/
+benchmarks/lockhammer/build.*/
+benchmarks/lockhammer/*.json
+*.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+
+
+# SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+.PHONY: help
+
+LOCKHAMMER_DIR=benchmarks/lockhammer
+
+help:
+	@echo
+	@echo "This Makefile passes to $(LOCKHAMMER_DIR)/Makefile"
+	@echo
+	@echo "try:"
+	@echo
+	@echo "   make -j 8 allvariants"
+	@echo
+
+%::
+	$(MAKE) -C $(LOCKHAMMER_DIR) $(MAKEFLAGS) $(MAKECMDGOALS)

--- a/benchmarks/lockhammer/Makefile
+++ b/benchmarks/lockhammer/Makefile
@@ -1,30 +1,129 @@
-# override keyword overwrites make command-line option LSE_ENABLE=y, therefore it has been removed
-CFLAGS += -g -O3 -I. -I./include -I../../ext/mysql/include -I../../ext/linux/include -I../../ext/tbb/include -I../../ext/sms/base
 
-ifneq ($(DEBUG_LEVEL),)
-ifeq ($(shell test $(DEBUG_LEVEL) -gt 0; echo $$?),0)
-CFLAGS+=-DDEBUG
-endif
-ifeq ($(shell test $(DEBUG_LEVEL) -gt 1; echo $$?),0)
-CFLAGS+=-DDDEBUG
-endif
-endif
-# LSE support is experimental, please enable the below CFLAGS with caution
-ifneq ($(LSE_ENABLE),)
-CFLAGS+=-march=armv8-a+lse -DUSE_LSE
-endif
-# Use builtin atomics instead of arch specific, if available
-ifneq ($(USE_BUILTIN),)
-CFLAGS+=-DUSE_BUILTIN
+# SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# This Makefile builds lockhammer binaries by test and configuration.
+#
+# TLDR:
+#      make -j 8 allvariants
+#
+#
+# The list of tests is in the TEST_TARGETS variable defined below.
+#
+# Additional variables passed on the command line control
+# build-time variants, such as use of LSE, compiler builtin
+# intrinsics, etc.  Executables for each variant combination are
+# placed into a separate build.xyz subdirectory, where xyz is
+# named for the build-time variant combination.
+#
+# The following phony targets provide convenience for building binaries.
+#
+# make all [variant variables]
+#     - builds binaries for all tests for the configuration variant
+#
+# make alli [variant variables]
+#     - generates preprocessed .i for all tests of the configuration variant of the set of variables
+#
+# make clean [variant variables]
+#     - remove the executables, binaries, and .i from the build directory of the variant
+#
+# make clobber [variant variables]
+#     - remove all files and the directory of the variant
+#
+# make allvariants
+#     - builds all binaries for all variant combinations
+#
+# make allivariants
+#     - generates preprocessed .i for all variant combinations
+#
+# make cleanallvariants
+#     - removes executables/binaries and .i of all variant builds
+#
+# make clobberallvariants
+#     - removes all files and directories for all variants
+#
+#
+# build variant variables
+# -----------------------
+#
+# USE_LSE=0/1       // aarch64 only
+#     0: do not use aarch64 LSE instructions (default if variable is not specified)
+#     1: use the aarch64 LSE instructions
+#
+#     The output for each setting will be placed in a separate build directory.
+#
+# USE_BUILTIN=0/1
+#     0: do not use the __atomic intrinsics and use arch-specific inline
+#        assembly instructions (default if variable is not specified)
+#     1: use the builtin __atomic intrinsics
+#
+#     The output for each setting will be placed in a separate build directory.
+#
+# USE_RELAX=setting
+#     what to use in cpu_relax() and equivalents -- value must be lowercase and one of the following
+#
+#     (unspecified)  'pause' instruction on x86_64, 'nothing' on aarch64
+#     pause          inline asm pause (x86_64 only)
+#     isb            inline asm isb (aarch64 only)
+#     nop            inline asm nop
+#     empty          inline asm volatile statement with no instruction
+#     nothing        no inline asm statement at all
+#
+#     The output for each setting will be placed in a separate build directory.
+#
+# USE_SMP_COND_LOAD_RELAXED=n	// effective on aarch64 only
+#     0: in osq_lock(), use a while loop to poll the lock variable. (default if variable is not specified)
+#     1: in osq_lock(), use the smp_cond_load_relaxed() macro instead polling between CPU_relax()
+#     Do a make clean if this make parameter is changed.
+#
+#     The output for each setting will be placed in a separate build directory.
+#
+# NO_JSON=n
+#     0: build with JSON output using libjansson (default if variable is not specified)
+#     1: do not build with libjansson support for JSON output.
+#     Do a make clean if this make parameter is changed.
+#
+# STATIC=n
+#     0: link dynamic binary. (default if variable is not specified)
+#     1: link static binary.
+#     Do a make clean if this make parameter is changed.
+#
+# SANITIZE=n
+#     0: do not use -fsanitize=address.  (default if variable is not specified)
+#     1: use -fsanitize=address.  Can not combine with STATIC=1.
+#     Do a make clean if this make parameter is changed.
+#
+# Examples:
+#
+# make USE_BUILTIN=1 USE_LSE=1 all
+#    -> makes binaries of all tests and places them in build.lse.builtin
+#
+# make USE_RELAX=empty build.relax_empty/measure.lh_ticket_spinlock.i
+#    -> outputs the preprocessed measure.c for ticket spinlock using the 'empty' relaxation method
+#
+#
+# Other variables
+# ---------------
+#
+# V=1
+#     show the executed command lines, e.g. make V=1
+#
+
+ifeq ($(V),1)
+empty :=
+hide = $(empty)
+else
+hide = @
 endif
 
+# can use 'make CC=clang LD=clang' as well
+LD = gcc
+CC = gcc
 
-LDFLAGS=-lpthread -lm
+TARGET_ARCH = $(shell $(CC) -dumpmachine | cut -d '-' -f 1)
 
-lh_%: tests/%.h include/atomics.h src/lockhammer.c 
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
-
-TARGET_ARCH:=$(shell ${CC} -dumpmachine | cut -d '-' -f 1)
+# executable targets by lock type
 
 TEST_TARGETS=lh_swap_mutex \
 	lh_event_mutex \
@@ -36,46 +135,567 @@ TEST_TARGETS=lh_swap_mutex \
 	lh_queued_spinlock \
 	lh_empty \
 	lh_jvm_objectmonitor \
-	lh_tbb_spin_rw_mutex \
 	lh_osq_lock \
-	lh_clh_spinlock
+	lh_clh_spinlock \
+	lh_tbb_spin_rw_mutex
+
+CURRENTLY_BROKEN_TARGETS=
 
 ifeq ($(TARGET_ARCH),aarch64)
 	TEST_TARGETS+=lh_hybrid_spinlock \
 		lh_hybrid_spinlock_fastdequeue
 endif
 
-all: ${TEST_TARGETS}
+# uncomment to redefine TEST_TARGETS to build just one lock test type
+#TEST_TARGETS=lh_osq_lock
+#TEST_TARGETS=lh_empty
+#TEST_TARGETS=lh_empty lh_osq_lock
+#TEST_TARGETS=lh_tbb_spin_rw_mutex
 
-lh_event_mutex: ../../ext/mysql/event_mutex.h include/atomics.h ../../ext/mysql/include/ut_atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+# debugging directive to show the make target
+#$(info MAKECMDGOALS=$(MAKECMDGOALS))
 
-lh_cas_event_mutex: ../../ext/mysql/cas_event_mutex.h include/atomics.h ../../ext/mysql/include/ut_atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
 
-lh_ticket_spinlock: ../../ext/linux/ticket_spinlock.h include/atomics.h ../../ext/linux/include/lk_atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+# header files' search paths
+INCLUDE = -I. -Iinclude -I../../ext/pagemap/include
+INCLUDE_MYSQL = -I ../../ext/mysql/include
+INCLUDE_LINUX = -I ../../ext/linux/include
+INCLUDE_SMS = -I ../../ext/sms/base
+INCLUDE_JVM = -I ../../ext/jvm/include
+INCLUDE_TBB = -I ../../ext/tbb/include
 
-lh_hybrid_spinlock: ../../ext/linux/hybrid_spinlock.h include/atomics.h ../../ext/linux/include/lk_atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
 
-lh_hybrid_spinlock_fastdequeue: ../../ext/linux/hybrid_spinlock_fastdequeue.h include/atomics.h ../../ext/linux/include/lk_atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+LDFLAGS = -pthread -lm -g
 
-lh_osq_lock: ../../ext/linux/osq_lock.h ../../ext/linux/include/lk_atomics.h ../../ext/linux/include/lk_barrier.h ../../ext/linux/include/lk_cmpxchg.h include/atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+ifeq ($(STATIC),1)
+LDFLAGS += -static
+endif
 
-lh_clh_spinlock: ../../ext/sms/clh_spinlock.h ../../ext/sms/base/build_config.h ../../ext/sms/base/cpu.h ../../ext/sms/base/llsc.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+CFLAGS = -g -O2 -fno-lto -Wall $(INCLUDE) -fno-stack-protector
+ifeq ($(CC),gcc)
+CFLAGS += -fstack-protector-explicit
+endif
 
-lh_queued_spinlock: ../../ext/linux/queued_spinlock.h include/atomics.h ../../ext/linux/include/lk_atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+# for making USE_BUILTIN=1 not call the out-of-line functions for aarch64 atomics
+#CFLAGS += -mno-outline-atomics
 
-lh_jvm_objectmonitor: ../../ext/jvm/jvm_objectmonitor.h include/atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+# set NDEBUG to disable assert() expression evaluation
+CFLAGS+=-DNDEBUG
 
-lh_tbb_spin_rw_mutex: ../../ext/tbb/tbb_spin_rw_mutex.h ../../ext/tbb/include/tbb.h include/atomics.h src/lockhammer.c
-	${CC} ${CFLAGS} -DNDEBUG -DATOMIC_TEST=\"$<\" src/lockhammer.c -o build/$@ ${LDFLAGS}
+# Debug level
+ifneq ($(DEBUG_LEVEL),)
+ifeq ($(shell test $(DEBUG_LEVEL) -ge 1; echo $$?),0)
+CFLAGS+=-DDEBUG
+endif
+
+ifeq ($(shell test $(DEBUG_LEVEL) -ge 2; echo $$?),0)
+CFLAGS+=-DDDEBUG
+CFLAGS+=-Wuse-after-free=3
+endif
+endif
+
+# address sanitizer flags
+ifeq ($(SANITIZE),1)
+CFLAGS+=-fsanitize=address -fno-omit-frame-pointer
+LDFLAGS+=-fsanitize=address
+endif
+
+# For "--json results.json" to save results using libjansson.
+# Build with NO_JSON=1 to disable, or install libjanssson-dev package.
+
+ifeq ($(NO_JSON),1)
+$(info NO_JSON=1, will not build with JSON output support)
+else
+CFLAGS+=-DJSON_OUTPUT
+LDFLAGS+=-ljansson
+endif
+
+LOCK_CFLAGS=
+
+# On arm, use the Large System Extensions instructions (FEAT_LSE) instead of exclusives.
+ifeq ($(USE_LSE),1)
+LOCK_CFLAGS+=-march=armv8-a+lse -DUSE_LSE
+endif
+
+# If USE_BUILTIN=1, use the __atomic intrinsics instead of arch-specific instructions
+ifeq ($(USE_BUILTIN),1)
+LOCK_CFLAGS+=-DUSE_BUILTIN
+endif
+
+
+# cpu_relax defaults
+# ------------------
+
+ifndef USE_RELAX
+ifeq ($(TARGET_ARCH),aarch64)
+$(info USE_RELAX is not defined, will use 'nothing' (no asm statement/instruction))
+USE_RELAX = nothing
+else ifeq ($(TARGET_ARCH),x86_64)
+$(info USE_RELAX is not defined, will use 'pause' for the 'pause' instruction)
+USE_RELAX = pause
+endif
+endif
+
+
+# cpu_relax implementation variants on x86_64
+# -------------------------------------------
+
+ifeq ($(TARGET_ARCH),x86_64)
+
+# Use the PAUSE instruction
+ifeq ($(USE_RELAX),pause)
+LOCK_CFLAGS+=-DRELAX_IS_PAUSE
+
+# Use an empty but volatile asm() statement
+else ifeq ($(USE_RELAX),empty)
+LOCK_CFLAGS+=-DRELAX_IS_EMPTY
+
+# Use no asm() statement at all
+else ifeq ($(USE_RELAX),nothing)
+LOCK_CFLAGS+=-DRELAX_IS_NOTHING
+
+endif
+endif
+
+# cpu_relax implementation variants on aarch64
+# --------------------------------------------
+
+ifeq ($(TARGET_ARCH),aarch64)
+
+# Use the ISB instruction
+ifeq ($(USE_RELAX),isb)
+LOCK_CFLAGS+=-DRELAX_IS_ISB
+
+# Use the NOP instruction
+else ifeq ($(USE_RELAX),nop)
+LOCK_CFLAGS+=-DRELAX_IS_NOP
+
+# Use an empty but volatile asm() statement
+else ifeq ($(USE_RELAX),empty)
+LOCK_CFLAGS+=-DRELAX_IS_EMPTY
+
+# Use no asm() statement at all
+else ifeq ($(USE_RELAX),nothing)
+LOCK_CFLAGS+=-DRELAX_IS_NOTHING
+
+endif
+endif
+
+
+# osq_lock - USE_SMP_COND_LOAD_RELAXED for primary loop
+# -----------------------------------------------------
+
+ifeq ($(USE_SMP_COND_LOAD_RELAXED),1)
+LOCK_CFLAGS+=-DUSE_SMP_COND_LOAD_RELAXED
+endif
+
+
+
+# ========================================================
+# output directory name construction
+
+VARIANT_NAME=
+
+ifeq ($(USE_LSE),1)
+VARIANT_NAME:=$(VARIANT_NAME).lse
+endif
+
+ifeq ($(USE_BUILTIN),1)
+VARIANT_NAME:=$(VARIANT_NAME).builtin
+endif
+
+ifeq ($(USE_SMP_COND_LOAD_RELAXED),1)
+VARIANT_NAME:=$(VARIANT_NAME).cond_load
+endif
+
+#ifeq ($(USE_RELAX),testme)
+#$(info lc USE_RELAX=$(USE_RELAX))
+#else ifeq ($(USE_RELAX),TESTME)
+#$(info uc USE_RELAX=$(USE_RELAX))
+#endif
+
+ifeq ($(USE_RELAX),isb)
+VARIANT_NAME:=$(VARIANT_NAME).relax_isb
+else ifeq ($(USE_RELAX),nop)
+VARIANT_NAME:=$(VARIANT_NAME).relax_nop
+else ifeq ($(USE_RELAX),pause)
+VARIANT_NAME:=$(VARIANT_NAME).relax_pause
+else ifeq ($(USE_RELAX),empty)
+VARIANT_NAME:=$(VARIANT_NAME).relax_empty
+else ifeq ($(USE_RELAX),nothing)
+VARIANT_NAME:=$(VARIANT_NAME).relax_nothing
+endif
+
+# strip the leading . in VARIANT_NAME, if any
+space:=$(subst ,, )
+VARIANT_NAME:=$(subst ., ,$(VARIANT_NAME))
+VARIANT_NAME:=$(strip $(VARIANT_NAME))
+VARIANT_NAME:=$(subst $(space),.,$(VARIANT_NAME))
+
+BUILD_DIR=build.$(VARIANT_NAME)
+LOCK_CFLAGS+=-DVARIANT_NAME=$(VARIANT_NAME)
+
+# ========================================================
+# build variant enumerations
+
+BUILTIN_VARIANTS = 0 1
+
+LSE_VARIANTS = 0
+ifeq ($(TARGET_ARCH),aarch64)
+LSE_VARIANTS += 1
+endif
+
+SMP_COND_LOAD_VARIANTS = 0 1
+
+ifeq ($(TARGET_ARCH),aarch64)
+RELAX_VARIANTS = isb nop empty nothing
+else
+RELAX_VARIANTS = empty pause nothing
+endif
+
+# compute all variant permutations
+ALL_VARIANTS = \
+	$(foreach BUILTIN,$(BUILTIN_VARIANTS), \
+		$(foreach LSE,$(LSE_VARIANTS), \
+			$(foreach SMP_COND_LOAD,$(SMP_COND_LOAD_VARIANTS), \
+				$(foreach RELAX,$(RELAX_VARIANTS), \
+					builtin_$(BUILTIN).lse_$(LSE).cond_load_$(SMP_COND_LOAD).relax_$(RELAX)))))
+
+# ---------------------
+# phony targets
+
+BUILD_ALL_VARIANTS = $(addprefix all.,$(ALL_VARIANTS))
+BUILD_ALLI_VARIANTS = $(addprefix alli.,$(ALL_VARIANTS))
+CLEAN_ALL_VARIANTS = $(addprefix clean.,$(ALL_VARIANTS))
+CLOBBER_ALL_VARIANTS = $(addprefix clobber.,$(ALL_VARIANTS))
+
+ALL_PHONY_VARIANTS = $(BUILD_ALL_VARIANTS) $(BUILD_ALLI_VARIANTS) $(CLEAN_ALL_VARIANTS) $(CLOBBER_ALL_VARIANTS)
+ALL_PHONY_TARGETS = $(ALL_PHONY_VARIANTS) $(ALL_CLEAN_TARGETS) info all allvariants allivariants Makefile info_variants
+ALL_CLEAN_TARGETS = $(CLEAN_ALL_VARIANTS) $(CLOBBER_ALL_VARIANTS) clean clobber cleanallvariants clobberallvariants
+
+# ---------------------
+# real target list
+
+ALL_BINARIES = $(addprefix $(BUILD_DIR)/,$(TEST_TARGETS))
+
+ALL_OBJS = $(HARNESS_OBJS) $(LOCK_OBJS)
+ALL_DEPS = $(HARNESS_DEPS) $(LOCK_DEPS)
+ALL_I = $(HARNESS_I) $(LOCK_I)
+
+# ---------------------
+# source file lists
+
+MEASURE_C_DEP_HEADERS = include/alloc.h include/lockhammer.h include/atomics.h include/perf_timer.h
+
+HARNESS_C_SRC = src/lockhammer.c src/alloc.c src/args.c src/report.c src/cpufreq-scaling-detect.c
+
+# lock code is inlined into measure.c using the -DATOMIC_TEST variable passed in as a compiler flag.
+# TODO: separate actual lock code from measure.c; also, LOCK_C_SRC must be just 1 file
+LOCK_C_SRC = src/measure.c
+
+C_SRC = $(HARNESS_C_SRC) $(LOCK_C_SRC)
+
+# ---------------------
+# compute the object names
+
+HARNESS_OBJS = $(addprefix $(BUILD_DIR)/,$(notdir $(HARNESS_C_SRC:%.c=%.o)))
+HARNESS_DEPS = $(addprefix $(BUILD_DIR)/,$(notdir $(HARNESS_C_SRC:%.c=%.d)))
+HARNESS_I = $(addprefix $(BUILD_DIR)/,$(notdir $(HARNESS_C_SRC:%.c=%.i)))
+
+LOCK_BASENAME = $(basename $(notdir $(LOCK_C_SRC)))
+LOCK_OBJS = $(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(addprefix $(LOCK_BASENAME).,$(TEST_TARGETS))))
+LOCK_DEPS = $(addprefix $(BUILD_DIR)/,$(addsuffix .d,$(addprefix $(LOCK_BASENAME).,$(TEST_TARGETS))))
+LOCK_I = $(addprefix $(BUILD_DIR)/,$(addsuffix .i,$(addprefix $(LOCK_BASENAME).,$(TEST_TARGETS))))
+
+
+# ---------------------
+# info for debugging make
+
+$(info BUILD_DIR = $(BUILD_DIR))                  # output build-dir
+#$(info HARNESS_OBJS = $(HARNESS_OBJS))           # benchmark harness object files
+#$(info LOCK_OBJS = $(LOCK_OBJS))                 # lock measurement object files
+#$(info HARNESS_DEPS = $(HARNESS_DEPS))           # benchmark harness dep files
+#$(info LOCK_DEPS = $(LOCK_DEPS))                 # lock measurement dep files
+#$(info $(BUILD_DIR)/$(notdir $(C_SRC:.c=.d)))
+
+# ---------------------
+# target expansion/selection functions
+# these save on the number of explicit recipes for the different variations
+
+# vartargs:  create build*, clean*, clobber* targets from 1st parameter.
+# e.g. $(call vartargs,builtin_0.lse_0) ->  build.builtin_0.lse_0 clean.builtin_0.lse_0 clobber.builtin_0.lse_0
+
+vartargs = $(addsuffix $1, all. alli. clean. clobber.)
+
+# targvar:  extract the first word from the argument.  It will be used for the nested make target.
+# e.g. $(call vartargs,all.builtin_0.lse_0) ---> all, for use as "make all"
+
+targvar = $(word 1, $(subst ., ,$1))
+
+#$(info call targvar,clean.builtin_0.lse_0 ---> $(call targvar,clean.builtin_0.lse_0))
+#$(info call targvar,clobber.builtin_0.lse_0 ---> $(call targvar,clobber.builtin_0.lse_0))
+#$(info call targvar,all.builtin_0.lse_0 ---> $(call targvar,all.builtin_0.lse_0))
+
+
+
+
+# --------------------------------------------------------
+# target recipes begin here
+
+.PHONY: $(ALL_PHONY_TARGETS)
+
+#info:  # this "info" target is used to show the values of variables and not actually build anything
+#	$(info $(ALL_VARIANTS))
+#
+#info_variants:
+#	$(info $(ALL_VARIANTS))
+
+all: $(ALL_BINARIES)
+
+alli: $(ALL_I)
 
 clean:
-	rm -f build/lh_*
+	@echo [CLEAN] all binaries, objects, preprocessed files in $(BUILD_DIR)
+	$(hide) rm -f $(ALL_BINARIES) $(ALL_OBJS) $(ALL_I)
+
+clobber: clean
+	@echo [CLOBBER] remove all dep files in $(BUILD_DIR) and the directory itself
+	$(hide) rm -f $(ALL_DEPS)
+	$(hide) rm -rf $(BUILD_DIR)
+
+allvariants: $(BUILD_ALL_VARIANTS)
+#	$(info BUILD_ALL_VARIANTS=$(BUILD_ALL_VARIANTS))
+
+allivariants: $(BUILD_ALLI_VARIANTS)
+#	$(info BUILD_ALLI_VARIANTS=$(BUILD_ALLI_VARIANTS))
+
+cleanallvariants: $(CLEAN_ALL_VARIANTS)
+
+clobberallvariants: $(CLOBBER_ALL_VARIANTS)
+
+# Explanation: if the goal is one of the clean/clobber targets,
+# then the clean/clobber target will precipiate from filter,
+# then this ifeq will fail, so the dep files will not be included,
+# so they will not be rebuilt.  This prevents make clean/clobber
+# from rebuilding the dep files.
+
+ifeq ($(filter $(ALL_CLEAN_TARGETS),$(MAKECMDGOALS)),)
+include $(HARNESS_DEPS)
+include $(LOCK_DEPS)
+endif
+
+# --------------------------------------------------------
+# variant-build targets
+
+# This template and the following loop generate recipes for the variant-build phony targets.
+# Each generated recipe recursively calls make with the variables for that variant-build.
+# e.g., this command
+#	make alli.builtin_1.lse_0.cond_load_1.relax_isb
+# runs this command in turn:
+#	make alli USE_BUILTIN=1 USE_LSE=0 USE_SMP_COND_LOAD_RELAXED=1 USE_RELAX=isb
+
+define TEMPLATE
+#$$(info $$(call vartargs,builtin_$(1).lse_$(2).cond_load_$(3).relax_$(4)))
+$$(call vartargs,builtin_$(1).lse_$(2).cond_load_$(3).relax_$(4)):
+	@echo $$(MAKE) $$(call targvar,$$@) USE_BUILTIN=$(1) USE_LSE=$(2) USE_SMP_COND_LOAD_RELAXED=$(3) USE_RELAX=$(4)
+	     @$$(MAKE) $$(call targvar,$$@) USE_BUILTIN=$(1) USE_LSE=$(2) USE_SMP_COND_LOAD_RELAXED=$(3) USE_RELAX=$(4)
+endef
+
+$(foreach BUILTIN,$(BUILTIN_VARIANTS), \
+	$(foreach LSE,$(LSE_VARIANTS), \
+		$(foreach SMP_COND_LOAD,$(SMP_COND_LOAD_VARIANTS), \
+			$(foreach RELAX,$(RELAX_VARIANTS), \
+				$(eval $(call TEMPLATE,$(BUILTIN),$(LSE),$(SMP_COND_LOAD),$(RELAX)) \
+				)))))
+
+
+# make output dir for this test variant
+$(BUILD_DIR):
+	$(hide) mkdir -p $@
+
+
+
+
+# ----------------------------------------------------------------------
+# recipes for building measure object files of specific locks
+
+
+# measure objects (.o) for specific external locks, i.e. $(BUILD_DIR)/measure.$lock_name.o
+
+$(BUILD_DIR)/measure.lh_event_mutex.o: ../../ext/mysql/event_mutex.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=event_mutex src/measure.c -c -o $@ $(INCLUDE_MYSQL)
+
+$(BUILD_DIR)/measure.lh_cas_event_mutex.o: ../../ext/mysql/cas_event_mutex.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=cas_event_mutex src/measure.c -c -o $@ $(INCLUDE_MYSQL)
+
+$(BUILD_DIR)/measure.lh_ticket_spinlock.o: ../../ext/linux/ticket_spinlock.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=ticket_spinlock src/measure.c -c -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_hybrid_spinlock.o: ../../ext/linux/hybrid_spinlock.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=hybrid_spinlock src/measure.c -c -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_hybrid_spinlock_fastdequeue.o: ../../ext/linux/hybrid_spinlock_fastdequeue.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=hybrid_spinlock_fastdequeue src/measure.c -c -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_osq_lock.o: ../../ext/linux/osq_lock.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=osq_lock src/measure.c -c -o $@ $(INCLUDE_LINUX) -DOSQ_LOCK
+
+$(BUILD_DIR)/measure.lh_clh_spinlock.o: ../../ext/sms/clh_spinlock.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=clh_spinlock src/measure.c -c -o $@ $(INCLUDE_SMS)
+
+$(BUILD_DIR)/measure.lh_queued_spinlock.o: ../../ext/linux/queued_spinlock.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=queued_spinlock src/measure.c -c -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_jvm_objectmonitor.o: ../../ext/jvm/jvm_objectmonitor.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=jvm_objectmonitor src/measure.c -c -o $@ $(INCLUDE_JVM)
+
+$(BUILD_DIR)/measure.lh_tbb_spin_rw_mutex.o: ../../ext/tbb/tbb_spin_rw_mutex.h | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=tbb_spin_rw_mutex src/measure.c -c -o $@ $(INCLUDE_TBB) -DNDEBUG
+
+
+
+# measure object depfiles (.d) for specific locks
+
+$(BUILD_DIR)/measure.lh_event_mutex.d: ../../ext/mysql/event_mutex.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=event_mutex src/measure.c $(INCLUDE_MYSQL)
+
+$(BUILD_DIR)/measure.lh_cas_event_mutex.d: ../../ext/mysql/cas_event_mutex.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=cas_event_mutex src/measure.c $(INCLUDE_MYSQL)
+
+$(BUILD_DIR)/measure.lh_ticket_spinlock.d: ../../ext/linux/ticket_spinlock.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=ticket_spinlock src/measure.c $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_hybrid_spinlock.d: ../../ext/linux/hybrid_spinlock.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=hybrid_spinlock src/measure.c $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_hybrid_spinlock_fastdequeue.d: ../../ext/linux/hybrid_spinlock_fastdequeue.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=hybrid_spinlock_fastdequeue src/measure.c $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_osq_lock.d: ../../ext/linux/osq_lock.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=osq_lock src/measure.c $(INCLUDE_LINUX) -DOSQ_LOCK
+
+$(BUILD_DIR)/measure.lh_clh_spinlock.d: ../../ext/sms/clh_spinlock.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=clh_spinlock src/measure.c $(INCLUDE_SMS)
+
+$(BUILD_DIR)/measure.lh_queued_spinlock.d: ../../ext/linux/queued_spinlock.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=queued_spinlock src/measure.c $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_jvm_objectmonitor.d: ../../ext/jvm/jvm_objectmonitor.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=jvm_objectmonitor src/measure.c $(INCLUDE_JVM)
+
+$(BUILD_DIR)/measure.lh_tbb_spin_rw_mutex.d: ../../ext/tbb/tbb_spin_rw_mutex.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=tbb_spin_rw_mutex src/measure.c $(INCLUDE_TBB) -DNDEBUG
+
+
+# preprocessed output (.i) for specific locks
+
+$(BUILD_DIR)/measure.lh_event_mutex.i: ../../ext/mysql/event_mutex.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=event_mutex src/measure.c -E -o $@ $(INCLUDE_MYSQL)
+
+$(BUILD_DIR)/measure.lh_cas_event_mutex.i: ../../ext/mysql/cas_event_mutex.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=cas_event_mutex src/measure.c -E -o $@ $(INCLUDE_MYSQL)
+
+$(BUILD_DIR)/measure.lh_ticket_spinlock.i: ../../ext/linux/ticket_spinlock.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=ticket_spinlock src/measure.c -E -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_hybrid_spinlock.i: ../../ext/linux/hybrid_spinlock.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=hybrid_spinlock src/measure.c -E -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_hybrid_spinlock_fastdequeue.i: ../../ext/linux/hybrid_spinlock_fastdequeue.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=hybrid_spinlock_fastdequeue src/measure.c -E -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_osq_lock.i: ../../ext/linux/osq_lock.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=osq_lock src/measure.c -E -o $@ $(INCLUDE_LINUX) -DOSQ_LOCK
+
+$(BUILD_DIR)/measure.lh_clh_spinlock.i: ../../ext/sms/clh_spinlock.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=clh_spinlock src/measure.c -E -o $@ $(INCLUDE_SMS)
+
+$(BUILD_DIR)/measure.lh_queued_spinlock.i: ../../ext/linux/queued_spinlock.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=queued_spinlock src/measure.c -E -o $@ $(INCLUDE_LINUX)
+
+$(BUILD_DIR)/measure.lh_jvm_objectmonitor.i: ../../ext/jvm/jvm_objectmonitor.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=jvm_objectmonitor src/measure.c -E -o $@ $(INCLUDE_JVM)
+
+$(BUILD_DIR)/measure.lh_tbb_spin_rw_mutex.i: ../../ext/tbb/tbb_spin_rw_mutex.h | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=tbb_spin_rw_mutex src/measure.c -E -o $@ $(INCLUDE_TBB) -DNDEBUG
+
+
+
+
+# measure object (.o) for generic locks -- preserve intermediate file that would otherwise be removed by make
+.PRECIOUS: $(BUILD_DIR)/measure.lh_%.o
+$(BUILD_DIR)/measure.lh_%.o: tests/%.h $(MEASURE_C_DEP_HEADERS) src/measure.c | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=$(basename $(notdir $<)) src/measure.c -c -o $@
+
+# preprocessed output (.i) for generic locks
+$(BUILD_DIR)/measure.lh_%.i: tests/%.h $(MEASURE_C_DEP_HEADERS) src/measure.c | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=$(basename $(notdir $<)) src/measure.c -E -o $@
+
+# measure dep file (.d) for generic locks
+$(BUILD_DIR)/measure.lh_%.d: tests/%.h src/measure.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) -DATOMIC_TEST=\"$<\" -DTEST_NAME=$(basename $(notdir $<)) src/measure.c
+
+
+# all other dep files (.d), including harness dep files
+$(BUILD_DIR)/%.d: src/%.c | $(BUILD_DIR)
+	@echo [CC -MM] $@
+	$(hide) $(CC) -o $@ -MM -MT '$(@:.d=.o) $(@:.d=.i) $@' $(CFLAGS) $(LOCK_CFLAGS) $<
+
+# all other binary objects (.o), including harness objects
+$(BUILD_DIR)/%.o: src/%.c | $(BUILD_DIR)
+	@echo [CC -c] $@
+	$(hide) $(CC) $(CFLAGS) $< -c -o $@
+
+# all other code preprocessed files (.i), including harness objects
+$(BUILD_DIR)/%.i: src/%.c | $(BUILD_DIR)
+	@echo [CC -E] $@
+	$(hide) $(CC) $(CFLAGS) $< -E -o $@
+
+
+
+# ----------------------------------------------------------------------
+# recipe for building executables
+
+.SECONDEXPANSION:
+
+# Explanation for using .SECONDEXPANSION:
+# If the target $@ will be something like lh_empty, then "measure.$$(notdir $$@).o"
+# makes "measure.lh_empty.o" a dependency.  Evaluating $$(nodir $$@) needs to be
+# done as a secondary expansion, which is why this is defined here.
+
+$(addprefix $(BUILD_DIR)/,$(TEST_TARGETS)): $(HARNESS_OBJS) $(BUILD_DIR)/measure.$$(notdir $$@).o | $(BUILD_DIR)
+	@echo [LD] $@
+	$(hide) $(LD) $^ $(LDFLAGS) -o $@

--- a/benchmarks/lockhammer/README.rst
+++ b/benchmarks/lockhammer/README.rst
@@ -1,10 +1,10 @@
 Lockhammer
 ==========
 
-This is a simple locks and sychronization performance evaulation tool which can
-be used to characterize the performance of high core-count systems or compare
-software algorithms.  Several basic primitives are included and third-party
-algorithms can easily be integrated.
+Lockhammer is a simple lock and synchronization performance evaluation tool
+which can be used to characterize the performance of high core-count systems or
+compare software algorithms.  Several basic primitives are included and
+third-party algorithms can easily be integrated.
 
 License
 -------
@@ -20,34 +20,98 @@ Build & Run
 ===========
 
 Simply 'make' in this directory to produce a lockhammer executable for each
-supported algorithm.  In order to more accurately characterize performance
-lockhammer selects the FIFO scheduler and as such must be run as root.  Be
-Aware that running FIFO scheduled threads on all cores for extended periods
-of time can result in responsiveness and stability issues.  Lockhammer should
-never be run on an already-deployed  system and parameters such as acquires
-per thread and critical section lengths should be tuned to ensure the entire
-run lasts for a short period of time.  Some simple scripts for running sweeps
-of different core counts is available in the `scripts/`_. directory.
+supported algorithm.
+
+The Makefile supports multiple build configuration variants selected using
+USe_* variables given to make.  The following example uses the __atomic
+intrinsics provided by the compiler instead of assembly routines provided by
+lockhammer (USE_BUILTIN=1) and an empty asm volatile ("") statement for the
+cpu_relax() macro (USE_RELAX+empty).
+
+	# build binaries into build.builtin.relax_empty
+	make USE_BUILTIN=1 USE_RELAX=empty
+
+	# delete binaries
+	make USE_BUILTIN=1 USE_RELAX=empty clean
+
+	# make preprocessed file.i for debugging
+	make USE_BUILTIN=1 USE_RELAX=empty alli
+
+See the comments at the top of the Makefile for a description of the variables.
+
+Because typing out all of the combinations of variables is tedious, the
+Makefile supports the phony target 'allvariants' that will build all of the
+combinations.  The Makefile also supports parallel builds.
+
+	# build all variants using 8 jobs at a time
+	make -j 8 allvariants
+
+	# make preprocessed file.i for all variants
+	make allivariants
+
+	# delete binaries of all variants
+	make cleanallvariants
+
+	# remove all files built for all variants
+	make clobberallvariants
+
+In order to more accurately characterize performance, lockhammer may be invoked
+to select the FIFO scheduler (using the flag "-S FIFO").  If this flag is used,
+then the test must be run as root.  Be aware that running FIFO scheduled
+threads on all cores for extended periods of time can result in responsiveness
+and stability issues.  When using this mode, lockhammer should not be run on an
+already-deployed system and parameters such as acquires per thread and critical
+section lengths should be tuned to ensure the entire run lasts for a short
+period of time.
+
+Some simple scripts for running sweeps of different core counts is available in
+the `scripts/`_. directory.
+
+- scripts/run-tests.sh is a new script that runs a series of test combinations.
+  The VARIANT_LIST, TEST_LIST, CRIT_NS_LIST, and PAR_NS_LIST variables in the
+  script can be edited to select which ones to run.  Each test generates a JSON
+  file.
+
+- scripts/view-results-json.sh is a new script that uses jq to summarize the
+  measurements from one or more JSON files.  Run 'scripts/view-results-json.sh
+  -h' for help.
 
 Locks or synchronization primitives are stressed by acquiring and releasing
-them at a rate deterimined by a command-line selectable number of critical
-and post-release wait loop iterations.  The default is to not wait between
-acquire and release or re-acquire attempts (acquire and release as quickly
-as possible).
+them at a rate determined by a command-line selectable number of critical and
+post-release (parallel) wait loop iterations.  However, the previous default of
+0 instructions for critical and 0 instructions for parallel are not realistic
+configurations.  The durations for these parameters must now be explicitly
+specified using the -c and -p flags.  (The values of -c 0 and -p 0 are still
+allowed, but are no longer the default.)
 
-Detailed information about each run is printed to stderr while a CSV summary
-is printed to stdout.
+Detailed information about each run is printed to stdout.  It can also be
+saved to a JSON file.
+
 
 Software Dependencies
 ---------------------
 
-+ gcc
++ gcc or clang
+
+Optional:
++ Jansson json library
++ jq
+
+Optional (for older scripts):
 + python3
 + sh python3 module
 + yaml python3 module
 
-Guide for Redhat Enterprise Linux 8.1
--------------------------------------
+Guide for Ubuntu 24.04
+----------------------
+apt install python3-sh libjansson-dev jq
+git clone https://github.com/ARM-software/synchronization-benchmarks.git
+cd synchronization-benchmarks/benchmarks/lockhammer
+make allvariants
+scripts/run-tests.sh
+
+Guide for Redhat Enterprise Linux 8.1 (old; not recently tested)
+----------------------------------------------------------------
 dnf install hwloc-gui
 pip3 install sh
 git clone https://github.com/ARM-software/synchronization-benchmarks.git
@@ -56,27 +120,121 @@ make
 cd scripts
 ./runall.sh
 
-Guide for Ubuntu 19.04
-----------------------
-apt install hwloc python3-sh
-git clone https://github.com/ARM-software/synchronization-benchmarks.git
-cd synchronization-benchmarks/benchmarks/lockhammer
-make
-cd scripts
-./runall.sh
 
 
 Usage
 =====
 
-The build system will generate a separate lockhammer binary for each test with
-the format lh_[testname]. Each lockhammer binary accepts the following options:
+The build system will make a directory named for the build configuration and
+place into it a separate lockhammer binary for each test named in the format
+lh_[testname].
+
+	$ ls -1 build.relax_pause/lh_*
+	build.relax_pause/lh_cas_event_mutex
+	build.relax_pause/lh_cas_lockref
+	build.relax_pause/lh_cas_rw_lock
+	build.relax_pause/lh_clh_spinlock
+	build.relax_pause/lh_empty
+	build.relax_pause/lh_event_mutex
+	build.relax_pause/lh_incdec_refcount
+	build.relax_pause/lh_jvm_objectmonitor
+	build.relax_pause/lh_osq_lock
+	build.relax_pause/lh_queued_spinlock
+	build.relax_pause/lh_swap_mutex
+	build.relax_pause/lh_tbb_spin_rw_mutex
+	build.relax_pause/lh_ticket_spinlock
+
+
+The minimum required flags to run a test:
+
+	* critical duration, one or more of the following:
+		-c instructions, --ci instructions
+		-c nanoseconds, --cn nanoseconds
+
+	* parallel duration, one or more of the following:
+		-p instructions, --pi instructions
+		-p nanoseconds, --pn nanoseconds
+
+	* workload length (time-based), one of the following
+		-T float_seconds
+		-O hwtimer_ticks
+
+	- OR -
+
+	* workload length (work-based) (not preferred)
+		-a num_acquires
+
+Example:
+
+	$ build.relax_pause/lh_ticket_spinlock -c 500 -p 500 -T 2
+
+	Starting test_name=ticket_spinlock variant_name=relax_pause
+	INFO: setting thread count to the number of available cores (24).
+	Finished running test_name=ticket_spinlock variant_name=relax_pause
+	po  cpus
+	0   0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+
+	po  meas  test  iter  thrds | cpu_ns/lock - crit_ns - par_ns  = overhead_ns % | lasom | locks/wall_sec
+	0   1     1     1     24    | 6801          98        101       6603      97% | 0.005 | 3528675
+
+
+When multiple -c, -p, or -o / -t flags are used, all permutations of these
+settings will be run.
+
+
+The supported flags are shown when a lockhammer binary is run with the -h flag:
 ::
-    [-t threads]    Number of threads to exercise, default online cores
-    [-a acquires]   Number of acquisitions per thread, default 50000
-    [-c critical]   Critical section in loop iterations, default 0
-    [-p parallel]   Parallelizable section in loop iterations, default 0
-    [-s]            Run in safe mode with normal priority threads instead of RT_FIFO priority, default no
+build.relax_pause/lh_empty [args]
+
+processor affinity selection (pick one of either -t or -o):
+ -o | --pinning-order   n:[n:[n...]]          arbitrary CPU pinning order set, separated by comma, colon, or hard space
+                                              A separate measurement will be conducted for each -o pinorder set.
+ -t | --num-threads           integer         number of worker threads to use
+ -i | --interleave-pinning    integer         number of hwthreads per core to algorithmically distribute worker threads using -t
+    1: per-core pinning/no SMT, 2: 2-way SMT pinning, 4: 4-way SMT pinning, etc.; these modes will override the existing scheduler processor affinity mask
+    0: enumerate CPUs from existing affinity mask
+ -C | --cpuorder-file         filename        for -t/--num-threads, allocate by CPU by number in order from this text file
+
+lock durations (at least one of both critical and parallel duration must be specified, and will be permuted):
+ -c | --critical              duration[ns|in] critical duration measured in nanoseconds (use "ns" suffix) or instructions (use "in" suffix; default is "in" if omitted)
+ -p | --parallel              duration[ns|in] parallel duration measured in nanoseconds (use "ns" suffix) or instructions (use "in" suffix; default is "in" if omitted)
+--cn| --critical-nanoseconds  nanoseconds     upon acquiring a lock, duration to hold the lock ("-c 1234ns" equivalent)
+--ci| --critical-instructions instructions    upon acquiring a lock, number of spin-loop instructions to run while holding the lock ("-c 1234in" equivalent)
+--pn| --parallel-nanoseconds  nanoseconds     upon releasing a lock, duration to wait before attempting to reacquire the lock ("-p 1234ns" equivalent)
+--pi| --parallel-instructions instructions    upon releasing a lock, number of spin-loop instructions to run while before attempting to reacquire the lock ("-p 1234in" equivalent)
+
+experiment iterations:
+ -n | --iterations            integer         number of times to run each measurement
+
+experiment length (work-based):
+ -a | --num-acquires          integer         number of acquires to do per thread
+
+experiment length (time-based):
+ -O | --run-limit-ticks       integer         each worker thread runs for this number of hardware timer ticks
+ -T | --run-limit-seconds     float_seconds   each worker thread runs for this number of seconds
+ -I | --run-limit-inner-iterations  integer   number of inner iterations of measurement between hardware timer polls
+      --hwtimer-frequency     freq_hertz      Override HW timer frequency in Hertz instead of trying to determine it
+      --estimate-hwtimer-frequency cpu_num    Estimate HW timer frequency on cpu_num
+      --timeout-usecs         integer         kill benchmark if it exceeds this number of microseconds
+
+scheduler control:
+ -S | --scheduling-policy     FIFO|RR|OTHER   set explicit scheduling policy of created threads (may need root)
+
+memory placement control (hugepages):
+ -M | --hugepage-size  <integer|help|default> mmap hugepages of a size listed in "-M help"
+      --print-hugepage-physaddr               print the physical address of the hugepage obtained, and then exit (must run as root)
+      --hugepage-offset       integer         if --hugepage-size is used, the byte offset into the hugepage for the tests' lock
+      --hugepage-physaddr     physaddr        obtain only the hugepage with the physaddr specified (must run as root)
+
+other:
+      --json filename                         save results to filename as a json
+ -Y | --ignore-unknown-scaling-governor       do not exit as error if CPU scaling driver+governor is known bad/not known good
+ -Z | --suppress-cpu-frequency-warnings       suppress CPU frequecy scaling / governor warnings
+ -v | --verbose                               print verbose messages
+      --more-verbose                          print even more verbose messages
+
+lock-specific:
+ -- <workload-specific arguments>             lock-specific arguments are passed after --
 
 
 Plotting
@@ -107,3 +265,257 @@ e.g. http://example.test.com:8888
 
 Click the notebook named lockhammer-jupyter-notebook.ipynb, run each cell one
 by one and jupyter should be able to generate the png graph locally.
+
+
+Using run-tests.sh and view-results-json.sh
+-------------------------------------------
+
+run-tests.sh and view-results-json.sh can be found in the scripts subdirectory.
+These scripts facilitate running many tests and summarizing the measurements.
+
+run-tests.sh runs the test binaries and variants found by permuting the entries
+in its VARIANT_LIST, TEST_LIST, CRIT_NS_LIST, and PAR_NS_LIST variables.  The
+script can be run with no arguments, but this will then try to run many
+permutations which will take hours.  Editing the variables in the script is
+advised to help focus the intent of measurements.
+
+
+	scripts/run-tests.sh
+
+
+Each test's results are stored in a json file named $HOSTNAME_S.$test.$BUILD_VARIANT.json
+
+These jsons can be summarized using the view-results-json.sh script, which will
+display a summary of all of the jsons given to it in one table.
+
+
+	scripts/view-results-json.sh \*.json
+
+
+The view-results-json.sh help message:
+
+./view-results-jsons.sh [options] json [json ...]
+
+select options:
+-c crit           nominal critical time/inst parameter (repeatable)
+-p par            nominal parallel time/inst parameter (repeatable)
+-t num_threads    number of threads (repeatable)
+-v variant_name   variant name (repeatable)
+
+sort options:
+-s sort_string    sort string (default is by '.num_threads')
+-s help           print short header to .key mapping
+-r                reverse the sort
+
+output options:
+-D                dump the records in a json array
+
+-h                print this usage help message
+
+
+Example:
+
+# list all data with threads=8, parallel=1000 or parallel=500, and critical=0
+# from files \*osq_lock\*.json, sort by overhead %
+
+./view-results-json.sh -s overhead_% -t 8 -p 1000 -p 500 -c 0 \*osq_lock\*.json
+
+
+
+Persistent Physical Memory for Locks Using Persistent Hugepages
+===============================================================
+
+The physical address of a lock variable may affect its
+performance.  For example, the address may be in a different NUMA
+domain than the originating domain.  Furthermore, memory
+performance can be different at granularities much smaller than a
+NUMA domain, such as a cache line.  However, the OS will provide
+a different virtual-to-physical memory mapping between
+invocations of a program.  Obtaining the same physical memory
+between runs can help to eliminate the randomization as a source
+of run-to-run performance variability.
+
+One way to reobtain the same physical memory is to reuse a
+persistent hugepage.  A "hugepage" in this context refers to the
+type of huge page that is associated with hugetlbfs (see [1]) and
+NOT the type provided by Transparent HugePage Support (THP).
+
+[1] https://docs.kernel.org/admin-guide/mm/hugetlbpage.html
+
+* A reserved, persistent hugepage is not movable nor decomposable
+  into base pages, so it maps to the same contiguous physical
+  memory between runs.
+
+* A single hugepage makes it easy for the same hugepage (and
+  therefore the same physical memory) to be mapped again
+  between runs.
+
+* Alternatively, if root access is available, the
+  --hugepage-physaddr flag can be used to try to request a hugepage
+  with a specific physical address, which will help reproducibility.
+
+
+Allocating a single hugepage
+----------------------------
+
+A hugepage can either be reserved at kernel boot or allocated
+afterwards if there is sufficient unfragmented memory.
+
+A hugepage at kernel boot can be allocated using the kernel
+parameters hugepagesz=<size> and hugepages=<N>.  The following
+parameters allocate one 1GB hugepage.  Note that these parameters
+are position-sensitive, and must be specified in the order shown.
+
+   hugepagesz=1G hugepages=1
+
+However, the kernel distributes the allocation of hugepages
+across NUMA nodes, so if only 1 hugepage is allocated, it will be
+only in one node that has the hugepage.
+
+Alternatively, a hugepage can be allocated after boot on a
+desired NUMA node.  The following instructions allocate 1 (and
+only 1) persistent hugepage of a supported size on the desired
+NUMA node, leaving 0 hugepages on all other nodes.
+
+Commands to run as root:
+
+# deallocate all 1GB hugepages on all NUMA nodes
+for a in /sys/devices/system/node/node*/hugepages/hugepages-1048576kB/nr_hugepages
+do
+    echo 0 > $a
+done
+
+# allocate a single 1 1GB hugepage on NUMA node 0
+echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
+
+
+Running Lockhammer with a Hugepage
+----------------------------------
+
+Invoke lockhammer with the --hugepage-size flag for the size
+of the single hugepage allocated.  This will cause the benchmark
+to map memory for the locks using mmap() with the MAP_HUGETLB flag.
+
+    lh_cas_lockref --hugepage-size 1g --hugepage-offset 64
+
+The --hugepage-offset flag provides even finer control over the
+physical address within the hugepage by specifying the byte offset
+in the page for the position of the lock.  The byte offset must
+be a multiple of 8; the default offset is 0 bytes.
+
+
+Requesting a hugepage by physical address
+-----------------------------------------
+
+When lockhammer is run as root (e.g., by invoking it with sudo),
+the physical address of the hugepage allocated will be printed in the
+output.
+
+    $ sudo build.relax_pause/lh_empty  -M default  -T 10 -o 8,9,10 --ignore-unknown-scaling-governor
+    using mmap with hugepagesz = default
+    determining timer frequency ...
+    found it as 2300000000 Hz (which could be wrong, use --estimate-timer-frequency to measure and --timer-frequency to override)
+    INFO: assuming default hugepage size is 2MB!
+    INFO: hugepage physaddr = 0x25c400000
+                              ^^^^^^ physical address of the hugepage
+
+On a subsequent run, the --hugepage-physaddr flag can then be used to
+map the same hugepage by physical address.  Lockhammer will try to
+llocate up to 10 hugepages to find one that has the requested physical
+address.
+
+    $ sudo build.relax_pause/lh_cas_rw_lock  -M default  -T 10 -o 8,9,10 --ignore-unknown-scaling-governor --hugepage-physaddr 0x25c400000
+    using mmap with hugepagesz = default
+    determining timer frequency ...
+    found it as 2300000000 Hz (which could be wrong, use --estimate-timer-frequency to measure and --timer-frequency to override)
+    INFO: assuming default hugepage size is 2MB!
+    INFO: hugepage physaddr = 0x25c400000
+                              ^^^^^^ the physical address is reused
+
+
+Allocation order of CPUs
+========================
+
+Each worker thread is pinned to a CPU using sched_setaffinity().
+
+The CPU number is determined based on the following:
+
+* explicit CPU pinorder (-o pinorder)
+
+    This places threads on CPU1, CPU2, and CPU3:
+
+        -o 1,2,3
+
+* number of threads (-t/--num-threads) starting from CPU0
+
+    This places threads on CPU0, CPU1, and CPU2:
+
+        -t 3
+
+* interleaving (-i/--interleave-pinning)
+
+    This changes the ordering of -t by skipping CPU numbers.
+
+    For example, this runs on CPU0, CPU2, and CPU4.
+
+        -t 3 -i 1
+
+    Note the CPU number is calculated by a formula and may
+    select a CPU core that is offline or not schedulable.
+
+    The special case of -i 0 allocates CPUs using the existing
+    CPU affinity mask to allow for discontiguous CPU numbers,
+    such as a system with disabled/offline CPUs.
+
+When -t/--num-threads is used, CPUs are allocated starting from CPU 0
+and up.  This can be changed by using the --cpuorder-file flag with a text
+file that contains the CPU numbers from which to allocate.  For example,
+if the file contains:
+
+        0 4 2 6 1 5 3 7
+
+Then invoking the benchmark with the flag -t 4 will allocate threads on
+CPU0, CPU4, CPU8, and CPU2 (instead of sequentially from CPU0-CPU3).
+
+
+
+Importance of Disabling Frequency Scaling
+=========================================
+
+set cpu frequency governor to performance
+
+for cpu in {0..127}; do
+sudo cpufreq-set -g performance -c $cpu
+done
+
+CPU frequency scaling
+---------------------
+
+Dynamic CPU frequency scaling may opportunistically increase performance by
+running certain cores at a higher frequency when they are loaded.  On some
+systems, the frequency under load depends on the number of other loaded CPUs
+and other factors.  Thus, the per-thread performance reported by the
+lockhammer benchmark may be higher when running on a few CPUs than when
+running on a large number of CPUs.  The per-thread performance may also be
+different when running within or between a logical or physical partition,
+such as a NUMA node or chiplet.
+
+Lockhammer inspects the CPU frequency scaling configuration to warn if the
+governor and frequency limits are not uniform across the target CPUs.  It
+also detects if the processor boosting control is enabled, which may
+increase the frequency above an all-core base frequency specified by the
+CPU frequency governor.  When enabled, these features may require further
+inspection and analysis to comprehend the benchmark's results.
+
+Here are some example commands to disable CPU frequency scaling features.
+
+Using cpufreq-utils to set base frequency to 2.2 GHz on CPUs 0-63 (acpi-cpufreq driver)
+	$ sudo bash -c 'for a in {0..63}; do cpufreq-set -g performance -d 2.2g -u 2.2g -c $a ; done'
+
+Disable processor boosting control (depends on the system and driver)
+	$ echo 0 | sudo tee -a /sys/devices/system/cpu/cpufreq/boost
+
+Note that some CPU frequency drivers expose controls to operate above the
+base core frequency, while other dirvers do not.  The configuration of
+the CPU frequency setting is platform specific, so the commands shown
+above may not work.

--- a/benchmarks/lockhammer/TODO
+++ b/benchmarks/lockhammer/TODO
@@ -1,0 +1,60 @@
+
+
+
+Physical address accessing strategy
+- While a specified physical address can be obtained by mmap /dev/mem with
+  CONFIG_STRICT_DEVMEM=n (and nopat on x86), we can not guarantee that memory
+  location is freely available for use.  This may be OK for simulation, but not
+  OK on a real system.
+
+  To get around this problem, find a physical address in a persistent hugepage.
+  This means not transparent hugepages, but HugeTLB pages.  Using a persistent
+  hugepage lets us access a physical memory that also persists after the
+  program ends so that there is repeatability.
+
+  TODO:  check that N=1 hugepages works with multiple NUMA domains (yes it
+         does, but since hugepages are default round-robin distributed ("interleaved")
+         across NUMA domains, N=1 will place only one hugepage in the first NUMA domain.
+         If other domains are to be tested, use --hugepage-physaddr to request the
+         hugepage with that physical address in that NUMA domain.)
+  TODO:  use get_mempolicy() to determine the NUMA domain of a hugepage.
+  TODO:  use fewer hugepages (done)
+  TODO:  add a flag to specify the hugepage physical address, and to try remapping
+         hugepages until it is obtained again. (done)
+  TODO:  use set_mempolicy(MPOL_BIND) to place a hugepage on a node instead of the above.
+  TODO:  respect hugepage size in bytes and in kilobytes by name; it only takes in the abbreviated one right now
+
+
+Update SpinPause() in ext/jvm/jvm_objectmonitor.h
+- The SpinPause() function returns 0.  However, this is only the case
+  in now very old versions of OpenJDK.  Modern versions use pause
+  on 64-bit x86 (amd64) and a parameterized choice of a one or more
+  ISB, or NOP on aarch64.
+
+
+ext/linux/hybrid_spinlock*
+- use the lockhammer lock pointer instead of malloc'ing mcs_pool for better reproducibility
+
+queued_spinlock
+- queued_spinlock uses the lock pointer as well as mcs_pool, so need a way to have both be reproducible.
+
+tbb_spin_rw_mutex
+- instead of doing operations on the state variable, use the test harness lock pointer for better reproducibility
+
+clh_spinlock
+- instead of operating on global_clh_lock, use the test harness lock pointer for better reproducibility
+
+ticket_spinlock
+- Modify so that USE_RELAX is effective
+
+
+cpufreq check:
+- for the intel_pstate driver, warn if no_turbo is set to 0
+
+
+
+
+add a memory update in the critical section
+- optionally store update on the same cacheline as the lock
+- expect a lot of kernel locks to have this
+- optionally store update somewhere else than the lock cache line (GUPS)

--- a/benchmarks/lockhammer/build/.gitignore
+++ b/benchmarks/lockhammer/build/.gitignore
@@ -1,4 +1,0 @@
-# Ignore build outputs
-*
-# But recognize build/ directory as part of repo
-!.gitignore

--- a/benchmarks/lockhammer/cpuorders/schema.txt
+++ b/benchmarks/lockhammer/cpuorders/schema.txt
@@ -1,0 +1,9 @@
+
+
+naming schema
+
+# cloud instance, should be a symlink to a system cpuorder
+<instance_type>.<cloud_provider>.cpuorder
+
+# system cpuorder
+<cpu_model>.<manufacturer>.cpuorder

--- a/benchmarks/lockhammer/include/alloc.h
+++ b/benchmarks/lockhammer/include/alloc.h
@@ -1,0 +1,63 @@
+
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef ALLOC_H
+#define ALLOC_H
+
+enum {
+    HUGEPAGES_NONE,
+    HUGEPAGES_DEFAULT,
+    HUGEPAGES_64K,
+    HUGEPAGES_2M,
+    HUGEPAGES_32M,
+    HUGEPAGES_512M,
+    HUGEPAGES_1G,
+    HUGEPAGES_16G,
+    HUGEPAGES_MAX_ENUM
+};
+
+
+void * do_hugepage_alloc(int use_hugepages, size_t hugepage_req_physaddr, int verbose);
+void * do_alloc(size_t length, int use_hugepages, size_t nonhuge_alignment, size_t hugepage_req_physaddr, int verbose);
+void print_hugepage_physaddr_and_exit(void * mmap_ret);
+
+// hugepage flag parameter parsing
+int parse_hugepage_parameter(const char * optarg);
+const char * hugepage_map (int enum_param_value);
+
+// function prototypes used by osq_lock
+uintptr_t get_phys_addr(uintptr_t vaddr);
+
+#endif
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/include/args.h
+++ b/benchmarks/lockhammer/include/args.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ARGS_H
+#define ARGS_H
+
+#include "lockhammer.h"
+
+int parse_args(int argc, char ** argv, test_args_t * pargs, const system_info_t * psysinfo);
+int init_sysinfo(system_info_t * psysinfo);
+void print_test_args(const test_args_t * p);
+
+#endif
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/include/cpu_relax.h
+++ b/benchmarks/lockhammer/include/cpu_relax.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CPU_RELAX_H
+#define CPU_RELAX_H
+
+
+#ifndef CPU_RELAX_ITERATIONS
+#define CPU_RELAX_ITERATIONS 1
+#endif
+
+static inline void __cpu_relax(void) {
+    for (unsigned long i = 0; i < CPU_RELAX_ITERATIONS; i++) {
+#ifdef __aarch64__
+#if defined(RELAX_IS_ISB)
+        asm volatile ("isb" : : : "memory" );
+#elif defined(RELAX_IS_NOP)
+        asm volatile ("nop" : : : "memory");
+#elif defined(RELAX_IS_EMPTY)
+        asm volatile ("" : : : "memory");
+#elif defined(RELAX_IS_NOTHING)
+
+#endif
+#endif // __aarch64__
+
+#ifdef __x86_64__
+
+#if defined(RELAX_IS_PAUSE)
+    // RELAX_IS_PAUSE is the implementation for x86 in jdk-9
+    asm volatile ("rep; nop"); // aka pause
+#elif defined(RELAX_IS_EMPTY)
+    asm volatile ("" : : : "memory");
+#elif defined(RELAX_IS_NOTHING)
+
+#endif
+#endif // __x86_64__
+
+    }
+}
+
+#endif // CPU_RELAX_H
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/include/lockhammer.h
+++ b/benchmarks/lockhammer/include/lockhammer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
  *
  * SPDX-License-Identifier:    BSD-3-Clause
  *
@@ -33,49 +33,187 @@
 #define __LOCKHAMMER_H__
 
 
-#ifndef initialize_lock
-    #define initialize_lock(lock, thread)
-#endif
-#ifndef parse_test_args
-    #define parse_test_args(args, argc, argv)
-#endif
-#ifndef thread_local_init
-    #define thread_local_init(smtid)
-#endif
+// PROGRESS_TICK_PROFILE - prints each thread's timer value at lock_acquires milestones to show thread concurrency
+#define PROGRESS_TICK_PROFILE
 
 enum units { NS,
-             INSTS };
+             INSTS, NOT_SET };
 typedef enum units Units;
 
-struct thread_args {
-    unsigned long ncores;
-    unsigned long nthrds;
-    unsigned long ileave;
-    unsigned long iter;
-    unsigned long *lock;
-    unsigned long *rst;
-    unsigned long *nsec;
-    unsigned long *real_nsec;
-    unsigned long *depth;
-    unsigned long *nstart;
-    unsigned long hold, post;
-    Units hold_unit, post_unit;
-    double tickspns;
-    int *pinorder;
-};
-typedef struct thread_args thread_args;
+#define _stringify(x) #x
+#define stringify(x) _stringify(x)
 
-struct test_args {
-    unsigned long nthrds;
-    unsigned long nacqrs;
-    unsigned long ncrit;
-    Units ncrit_units;
-    unsigned long nparallel;
-    Units nparallel_units;
-    unsigned long ileave;
-    unsigned char safemode;
-    int *pinorder;
-};
-typedef struct test_args test_args;
+// per_thread_results_t - each thread returns its results in this struct (inside thread_args_t)
+typedef struct {
+    unsigned long cpu_affined;  // which CPU this was pinned on.
+
+    unsigned long lock_acquires;// number of locks acquired-and-released per thread
+    unsigned long cputime_ns;   // this thread's CPU time in nanoseconds
+    unsigned long walltime_ns;  // this thread's wall clock time in nanoseconds
+    unsigned long hmrdepth;     // depth=lock-specific notion of contention
+
+    unsigned long hwtimer_start; // timer value at start of measurement loop
+    unsigned long hwtimer_end;   //         "'  at end
+
+    unsigned long hwtimer_10p;   // timer value at 10% of work completion
+    unsigned long hwtimer_25p;   //         ""  at 25%
+    unsigned long hwtimer_50p;   //         ""  at 50%
+    unsigned long hwtimer_75p;   //         ""  at 75%
+    unsigned long hwtimer_90p;   //         ""  at 90%
+
+    // hold/post durations from calibrate_timer()
+    double hold_ns, post_ns;
+
+    // metrics only for osq_lock
+    unsigned long osq_lock_wait_next_spins;
+    unsigned long osq_unlock_wait_next_spins;
+    unsigned long osq_lock_locked_spins;
+    unsigned long osq_lock_unqueue_spins;
+    unsigned long osq_lock_acquire_backoffs;
+
+} per_thread_results_t;
+
+
+// thread_args_t -- pointer to an instance of this is passed to each thread
+typedef struct {
+    unsigned long thread_num;       // thread number, ordinal 0
+    unsigned long num_threads;      // number of worker threads in total for experiment
+    unsigned long num_acquires;     // -a flag, aka nacqrs, aka number of acquires per thread to do
+    unsigned long *lock;            // pointer to the lock variable
+
+    unsigned long *p_start_ns;      // marshal thread's monotonic start time, in ns, for computing wall_elapsed_ns; only marshall thread sets this
+    unsigned long hold, post;       // ncrit, nparallel
+    Units hold_unit, post_unit;     // NS or INSTS, hold_unit = ncrit_units, post_unit = nparallel_units
+    unsigned long hold_count;
+    unsigned long post_count;
+
+    double tickspns;                // number of ticks_per_ns
+
+    unsigned long run_on_this_cpu;  // logical CPU on which a worker thread is to run
+
+    unsigned long run_limit_ticks;  // if non-zero, the number of timer ticks to run for when using --run-limit-ticks or --run-limit-seconds
+    unsigned long run_limit_inner_loop_iters;  // the number of lock acquire/release sequences to run before checking the hwtimer when using --run-limit-ticks or --run-limit-seconds
+    unsigned long hwtimer_frequency;
+
+    int verbose;
+    unsigned long blackhole_numtries;
+
+    per_thread_results_t results;   // output data structure
+
+} thread_args_t;
+
+// pinorder_t - describes a set of CPUs on which to run worker threads
+typedef struct {
+    int * cpu_list;     // pointer to an array of int.  index into this array is the thread number, each element is the logical CPU on which that thread is to run.
+    size_t num_threads; // number of threads defined for this pinorder (i.e. length of the number of valid entries in the pinorder array).
+} pinorder_t;
+
+
+typedef struct {
+    unsigned long t;   // duration time, either in nanoseconds or iterations
+    Units unit;        // duration unit, either NS or INSTS
+} duration_t;
+
+// test_args_t - mostly command line parameters
+typedef struct {
+    unsigned long num_acquires;  // -a    number of acquires (not documented?)
+    duration_t * crits;     // -c, --cn=, --ci=    critical duration
+    duration_t * pars;      // -p, --pn=, --pi=    parallel duration
+    size_t num_crits;
+    size_t num_pars;
+    unsigned long ileave;    // -i    interleave value for SMT pinning
+    int scheduling_policy;   // -S    use explicit scheduling policy
+    size_t num_pinorders;
+    pinorder_t * pinorders;  // -o    CPU pinning order
+    unsigned long  timeout_usec;   // -A  timeout_usec
+
+    int hugepagesz;
+    int use_mmap;
+    int mmap_hugepage_offset_exists;
+    int print_hugepage_physaddr;
+    size_t mmap_hugepage_offset;
+    size_t mmap_hugepage_physaddr;
+    unsigned long hwtimer_frequency;
+    unsigned long probed_hwtimer_frequency;
+    long estimate_hwtimer_freq_cpu;
+
+    double run_limit_seconds;
+    unsigned long run_limit_ticks;
+    unsigned long run_limit_inner_loop_iters;
+    int ignore_unknown_scaling_governor;
+    int suppress_cpu_frequency_warnings;
+    const char * cpuorder_filename;
+#ifdef JSON_OUTPUT
+    const char * json_output_filename;
+#endif
+#ifdef __aarch64__
+    char disable_outline_atomics_lse;
+#endif
+    int verbose;
+    size_t iterations;
+    size_t blackhole_numtries;
+} test_args_t;
+
+// system_info_t - system configuration data
+typedef struct {
+    unsigned long num_cores;    // number of processors configured by the operating system
+    size_t page_size_bytes;     // page size in bytes
+    size_t erg_bytes;           // number of bytes per exclusive reservation granule (e.g. cache line/block)
+
+    cpu_set_t avail_cores;      // cores that the CPU affinity mask allows us to run on
+    size_t num_avail_cores;     // number of cores that the CPU affinity mask allows us to run on
+    size_t num_online_cores;    // the number of cores that getconf _NPROCESSORS_ONLN returns
+
+    // num_online_cores can be less than num_cores because some may be offline or not permitted by affinity mask
+    // num_avail_cores may be less than num_online_cores because some online cores may be isolated
+} system_info_t;
+
+// locks_t -- pointers to the actual locks to be used
+typedef struct {
+    unsigned long * p_test_lock;        // address of main lock
+    unsigned long * p_ready_lock;       // lock to synchronize all threads' entry into hmr()
+    unsigned long * p_sync_lock;        // lock to synchronize before blackhole cabliration
+    unsigned long * p_calibrate_lock;   // lock to synchronize after blackhole calibration
+} locks_t;
+
+// calibrate_blackhole -- (used in osq_lock)
+unsigned long calibrate_blackhole(unsigned long target, unsigned long tokens_low, unsigned long tokens_high, unsigned long core_id, unsigned long NUMTRIES);
+
+// evaluate_blackhole -- returns average duration of NUMTRIES
+int64_t evaluate_blackhole( const unsigned long tokens_mid, const unsigned long NUMTRIES);
+
+// blackhole() -- runs a small loop to consume time (also used in osq_lock)
+void blackhole(unsigned long iters);
+
+// measure_setup_initialize_lock() -- calls lock-specific setup routine if it exists
+void measure_setup_initialize_lock(locks_t * p_locks, pinorder_t * pinorder);
+
+// measure_setup_parse_test_args() -- calls lock-specific parsing routine if it exists
+void measure_setup_parse_test_args(test_args_t * p_test_args, int argc, char ** argv);
+
+// convert the struct timespec to only nanoseconds
+unsigned long timespec_to_ns (struct timespec * ts);
+
+// selectively disable LSE instructions in outline atomics/libgcc; in measure.c
+void handle_disable_outline_atomics_lse(void);
+
+#if __GNUC__==1
+#define NOINLINE __attribute__((noinline))
+#elif __clang__==1
+#define NOINLINE __attribute__((noinline))
+#else
+#define NOINLINE
+#endif
+
+#if __GNUC__==1
+#define NO_UNROLL_LOOP _Pragma("GCC unroll 0")
+#elif __clang__==1
+#define NO_UNROLL_LOOP _Pragma("clang loop unroll(disable)")
+#else
+#define NO_UNROLL_LOOP
+#endif
+
 
 #endif
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/include/verbose.h
+++ b/benchmarks/lockhammer/include/verbose.h
@@ -1,0 +1,19 @@
+
+/*
+ * SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef VERBOSE_H
+#define VERBOSE_H
+
+enum {
+    VERBOSE_MORE=3,
+    VERBOSE_YES=2,
+    VERBOSE_LOW=1,    // default
+    VERBOSE_NONE=0    // to-be-implemented
+};
+
+#endif
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/scripts/run-tests.sh
+++ b/benchmarks/lockhammer/scripts/run-tests.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# This script invokes lockhammer tests.
+# This script is meant to be edited for customizing which tests to run.
+# Edit the *_LIST variables below to choose the configuration combinations.
+# A json file will be made for each variant and test combination.
+
+set -e
+
+usage() {
+cat<<USAGE
+
+run-tests.sh [options]
+
+options:
+
+-n       do a dry run
+-P skip  processor skip step above 8 CPUs (default $CPU_SKIP)
+         For example, -P 16 will measure 2, 4, 8, 24, 40...
+-T sec   duration of each measurement in seconds (default $DURATION_SECONDS)
+-h       print this usage help message
+
+USAGE
+	exit 1
+}
+
+CPU_SKIP=8
+DRY_RUN=0
+DURATION_SECONDS=0.5
+IGNORE_UNKNOWN_SCALING_GOVERNOR=-Y
+
+shopt -s extglob
+
+while getopts ":nP:T:h" name; do
+	case "${name}" in
+		n)	DRY_RUN=1
+			;;
+		P)	CPU_SKIP=${OPTARG}
+			;;
+		T)	DURATION_SECONDS=${OPTARG}
+			;;
+		h)	usage
+			;;
+		:)	>&2 echo "ERROR: flag -$OPTARG required an argument, but none was given"
+			usage
+			;;
+		*)	echo name=$name, OPTARG=$OPTARG
+			usage
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+
+# make the list of build variants to run; use # to comment out variant
+
+# TODO: update lists by arch
+
+VARIANT_LIST=$(grep -v -E '\#|^$' <<'EOF1'
+builtin.cond_load.relax_empty
+builtin.cond_load.relax_nothing
+builtin.cond_load.relax_pause
+builtin.relax_empty
+builtin.relax_nothing
+builtin.relax_pause
+cond_load.relax_empty
+cond_load.relax_nothing
+cond_load.relax_pause
+relax_empty
+relax_nothing
+relax_pause
+
+
+#builtin.relax_nothing
+#builtin.relax_isb
+#builtin.cond_load.relax_nothing
+#builtin.cond_load.relax_isb
+
+#lse.builtin.relax_nothing
+#lse.builtin.relax_isb
+#lse.builtin.cond_load.relax_nothing
+#lse.builtin.cond_load.relax_isb
+EOF1
+)
+
+# make the list of tests to run; use # to comment out test
+
+TEST_LIST=$(grep -v -E '\#|^$' <<'EOF2'
+lh_cas_event_mutex
+lh_cas_lockref
+lh_cas_rw_lock
+#lh_clh_spinlock
+#lh_empty
+#lh_event_mutex
+#lh_hybrid_spinlock
+#lh_hybrid_spinlock_fastdequeue
+lh_incdec_refcount
+lh_jvm_objectmonitor
+lh_osq_lock
+#lh_queued_spinlock
+#lh_swap_mutex
+#lh_tbb_spin_rw_mutex
+lh_ticket_spinlock
+EOF2
+)
+
+CRIT_NS_LIST=$(grep -v -E '\#|^$' <<'EOF_CRIT_NS'
+0
+500
+1000
+EOF_CRIT_NS
+)
+
+PAR_NS_LIST=$(grep -v -E '\#|^$' <<'EOF_PAR_NS'
+0
+500
+1000
+2000
+4000
+EOF_PAR_NS
+)
+
+PAR=""
+for a in $PAR_NS_LIST; do PAR+="-p${a}ns "; done
+
+CRIT=""
+for a in $CRIT_NS_LIST; do CRIT+="-c${a}ns "; done
+
+
+# check that a hugepage is available
+#HUGEPAGE_SIZE=32MB
+#HUGEPAGE_SIZE_KB=$((32*1024))
+HUGEPAGE_SIZE=1GB
+HUGEPAGE_SIZE_KB=$((1024*1024))
+HUGEPAGES_DIR=/sys/kernel/mm/hugepages/hugepages-${HUGEPAGE_SIZE_KB}kB
+FREE_HUGEPAGES_FILE=$HUGEPAGES_DIR/free_hugepages
+NR_HUGEPAGES_FILE=$HUGEPAGES_DIR/nr_hugepages
+NR_HUGEPAGES=$(cat "$NR_HUGEPAGES_FILE")
+NR_HUGEPAGES_PLUS_ONE=$((NR_HUGEPAGES+1))
+if [ ! -e "$FREE_HUGEPAGES_FILE" ] || [ $(cat "$FREE_HUGEPAGES_FILE") -eq 0 ]; then
+	echo "ERROR: no free $HUGEPAGE_SIZE hugepages.  Perhaps try running:"
+	echo "echo $NR_HUGEPAGES_PLUS_ONE | sudo tee -a $NR_HUGEPAGES_FILE"
+	exit -1
+fi
+HUGEPAGE_FLAGS="--hugepage-size $HUGEPAGE_SIZE"
+
+
+# determine cpuorder file to use based on hostname.
+HOSTNAME_S=$(hostname -s)
+CPUORDER_FLAGS=
+if [ -e hostname_to_cpuorder_type.sh ]; then
+	. hostname_to_cpuorder_type.sh
+
+	CPUORDER_TYPE=$(hostname_to_cpuorder_type $HOSTNAME_S)
+	CPUORDER=cpuorders/$CPUORDER_TYPE.cpuorder
+
+	if [ ! -e "$CPUORDER" ]; then
+		echo "ERROR:  $CPUORDER does not exist!"
+		exit -1
+	fi
+
+	CPUORDER_FLAGS="-C $CPUORDER"
+fi
+
+# compute the number of threads using the number of available processors
+NPROC=$(nproc)
+TLIST=
+for num_threads in 2 4 $(eval echo "{8..$NPROC..$CPU_SKIP}")
+do
+	if [ $num_threads -gt $NPROC ]; then
+		break
+	fi
+
+	TLIST+="-t $num_threads "
+done
+
+
+# compute number of test and variants
+NUM_TESTS=$(echo $TEST_LIST | wc -w)
+NUM_VARIANTS=$(echo $VARIANT_LIST | wc -w)
+#echo NUM_VARIANTS=$NUM_VARIANTS NUM_TESTS=$NUM_TESTS
+NUM_TEST_AND_VARIANTS=$((NUM_TESTS*NUM_VARIANTS))
+TEST_AND_VARIANT_COUNT=0
+#echo NUM_TEST_AND_VARIANTS=$NUM_TEST_AND_VARIANTS
+
+#exit 0
+
+# change newline to space for the summary
+TEST_LIST=${TEST_LIST//$'\n'/ }
+VARIANT_LIST=${VARIANT_LIST//$'\n'/ }
+PAR_NS_LIST=${PAR_NS_LIST//$'\n'/ }
+CRIT_NS_LIST=${CRIT_NS_LIST//$'\n'/ }
+
+cat<<SUMMARY
+hostname            = $HOSTNAME_S
+cpuorder            = $CPUORDER
+num_threads         = ${TLIST//-t /}
+variants            = $VARIANT_LIST
+tests               = $TEST_LIST
+critical times (ns) = $CRIT_NS_LIST
+parallel times (ns) = $PAR_NS_LIST
+duration (sec)      = $DURATION_SECONDS
+hugepage flags      = $HUGEPAGE_FLAGS
+SUMMARY
+
+echo
+echo ------------------------------------------------------
+echo beginning measurements at: $(date)
+echo ------------------------------------------------------
+
+START_EPOCHSECONDS=$EPOCHSECONDS
+
+for BUILD_VARIANT in $VARIANT_LIST
+do
+
+for test in $TEST_LIST
+do
+
+	TEST_AND_VARIANT_COUNT=$((TEST_AND_VARIANT_COUNT+1))
+	echo
+	echo running $TEST_AND_VARIANT_COUNT of $NUM_TEST_AND_VARIANTS test+variant combinations
+	echo
+
+	EXE=build.$BUILD_VARIANT/$test
+	JSON=$HOSTNAME_S.$test.$BUILD_VARIANT.json
+	CMD="$EXE $IGNORE_UNKNOWN_SCALING_GOVERNOR $PAR $CRIT -T $DURATION_SECONDS $CPUORDER_FLAGS $HUGEPAGE_FLAGS $TLIST --json $JSON"
+
+	if [ ! -x "$EXE" ]; then
+		echo ERROR: $EXE is not found or not executable, skipping test
+		continue
+	fi
+
+	if [ -e "$JSON" ]; then
+		echo ERROR: $JSON already exists, will not overwrite, skipping test
+		continue
+	fi
+
+	echo
+	if [ $DRY_RUN -eq 0 ]; then
+		echo $CMD
+		echo
+		$CMD
+	else
+		echo This is a DRY RUN -- the following command will not be executed:
+		echo
+		echo $CMD
+	fi
+done
+done
+
+FINISH_EPOCHSECONDS=$EPOCHSECONDS
+ELAPSED_SECONDS=$((FINISH_EPOCHSECONDS-START_EPOCHSECONDS))
+if [ $ELAPSED_SECONDS -ge 86400 ]; then
+ELAPSED_TIME=$(date -u -d @$ELAPSED_SECONDS +%j:%T)
+else
+ELAPSED_TIME=$(date -u -d @$ELAPSED_SECONDS +%T)
+fi
+
+echo
+echo ------------------------------------------------------
+echo finished measurements at: $(date)
+echo elapsed time: $ELAPSED_TIME
+echo ------------------------------------------------------

--- a/benchmarks/lockhammer/scripts/show-per-thread-lock-acquires.sh
+++ b/benchmarks/lockhammer/scripts/show-per-thread-lock-acquires.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# This script shows the per-thread fairness of lock acquires in the result json(s).
+
+# show-per-thread-lock-acquires.sh result1.json [result2.json ...]
+
+# add this to filter only one set of crit/par
+#.results[]|select(.nominal_critical==0 and .nominal_parallel==0)|
+
+read -r -d '' CMD <<'EOF'
+.results[]|"\(.nominal_critical)\t\(.nominal_parallel)\t\(.num_threads)\t\(.full_concurrency_fraction*10000|round/10000)\t\(.lock_acquires_mean | round )\t\(.lock_acquires_stddev_over_mean * 10000 | round / 10000)\t\(.per_thread_stats | map(.lock_acquires) | sort | join(","))"
+EOF
+
+#echo "$CMD"
+#exit
+
+(
+echo -e "crit\tpar\tnthrds\tfcf\tlock_acquires_mean\tlock_acquires_stddev/mean\tlock_acquires_each_thread\n"
+jq -r "$CMD" "$@"
+) | column -t

--- a/benchmarks/lockhammer/scripts/view-results-json.sh
+++ b/benchmarks/lockhammer/scripts/view-results-json.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# This script displays the values from one or more lockhammer json files in a table format using jq.
+
+# XXX: can't differentiate between ns vs. inst for crit/par; please select only using the same units!
+
+SORT_STRING='.num_threads'
+REVERSE=0
+DUMP_DATA=0
+
+declare -a CRIT
+declare -a PAR
+declare -a NUM_THREADS
+declare -a VARIANT_NAMES
+
+usage() {
+cat<<"USAGE"
+
+./view-results-json.sh [options] json [json ...]
+
+select options:
+-c crit           nominal critical time/inst parameter (repeatable)
+-p par            nominal parallel time/inst parameter (repeatable)
+-t num_threads    number of threads (repeatable)
+-v variant_name   variant name (repeatable)
+
+sort options:
+-s sort_string    sort string (default is by '.num_threads')
+-s help           print short header to .key mapping
+-r                reverse the sort
+
+output options:
+-D                dump the records in a json array
+
+-h                print this usage help message
+
+
+Example:
+
+# list all data with threads=8, parallel=1000 or parallel=500, and critical=0
+# from files *osq_lock*.json, sort by overhead %
+
+./view-results-json.sh -s overhead_% -t 8 -p 1000 -p 500 -c 0 *osq_lock*.json
+
+USAGE
+	exit 1
+}
+
+
+shopt -s extglob
+
+while getopts ":c:p:t:v:s:rDh" name; do
+	case "${name}" in
+		c)	CRIT+=(${OPTARG})
+			;;
+		p)	PAR+=(${OPTARG})
+			;;
+		t)	NUM_THREADS+=(${OPTARG})
+			;;
+		v)	VARIANT_NAMES+=(${OPTARG})
+			;;
+		s)	SORT_STRING=${OPTARG}
+			;;
+		r)	REVERSE=1
+			;;
+		D)	DUMP_DATA=1
+			;;
+		h)	usage
+			;;
+		:)	>&2 echo "ERROR: flag -$OPTARG required an argument, but none was given"
+			usage
+			;;
+		*)	echo "ERROR: unknown flag name=$name, OPTARG=$OPTARG"
+			usage
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+
+FILES="$@"
+
+if [ -z "$FILES" ]; then
+	echo "no json files given; run with -h for usage help"
+        exit -1
+fi
+
+# -----------------------------------------------------------------------------
+# jq filter stages. Write as separate single-quoted strings so that escapes are not needed (i.e., do not use escapes!).
+#
+# reducer   - puts data from all the json into an array with some modifications
+# selector  - selects the data from the array that match the command line criteria
+# sorter    - sort the selected data by the sorting criteria
+# filter    - convert the sorted data into formatted output
+
+# ----------------------------------
+# Reducer gets the .results[] array from each json, and, for each results
+# element/object, deletes the pinorder and per_thread_sets, and adds an
+# .input_filename to the object.  The output is a single array of results
+# elements.
+
+REDUCER='reduce inputs as $s ([]; . += [$s.results[] | del(.pinorder) | del(.per_thread_stats) | . += {"input_filename":input_filename}])'
+
+
+# ----------------------------------
+# Select the records with the requested element values
+
+make_selector() {
+local NAME="$1"
+shift
+local AS_STRING=0
+if [ "$1" = "as_string" ]; then
+	AS_STRING=1
+	shift
+elif [ "$1" = "as_number" ]; then
+	AS_STRING=0
+	shift
+fi
+
+local ARRAY=("$@")
+local ARRAY_SELECTOR=
+
+if [ ${#ARRAY[@]} -eq 0 ]; then
+	return
+fi
+
+for a in ${ARRAY[@]}; do
+	if [ -n "$ARRAY_SELECTOR" ]; then ARRAY_SELECTOR+=" or "; fi
+	if [ $AS_STRING -eq 1 ]; then
+		ARRAY_SELECTOR+=".${NAME}==\"${a}\""
+	else
+		ARRAY_SELECTOR+=".${NAME}==${a}"
+	fi
+done
+
+echo " and ($ARRAY_SELECTOR)"
+}
+
+SELECTOR_ARGLIST="true"
+SELECTOR_ARGLIST+=$(make_selector nominal_parallel "${PAR[@]}")
+SELECTOR_ARGLIST+=$(make_selector nominal_critical "${CRIT[@]}")
+SELECTOR_ARGLIST+=$(make_selector num_threads "${NUM_THREADS[@]}")
+SELECTOR_ARGLIST+=$(make_selector variant_name as_string "${VARIANT_NAMES[@]}")
+
+SELECTOR=' [.[] | select('$SELECTOR_ARGLIST')] '
+
+
+# ----------------------------------
+# Sort; output is an array
+
+# for -s sort_string flag, map it to these fields.  TODO: reverse SPECIAL_HEADER array instead of hard-coding
+declare -A SHORT_HEADER
+SHORT_HEADER[cputime_ns/lock]=".cputime_ns_per_lock_acquire"
+SHORT_HEADER[cpu_ns/lock]=".cputime_ns_per_lock_acquire"
+SHORT_HEADER[wall_ns/lock]=".wall_elapsed_ns_per_lock_acquire"
+SHORT_HEADER[fcf]=".full_concurrency_fraction"
+SHORT_HEADER[nom_par]=".nominal_parallel"
+SHORT_HEADER[nom_crit]=".nominal_critical"
+SHORT_HEADER[par_ns]=".avg_parallel_ns_per_loop"
+SHORT_HEADER[crit_ns]=".avg_critical_ns_per_loop"
+SHORT_HEADER[overhead_ns]=".avg_lock_overhead_cputime_ns"
+SHORT_HEADER[overhead_%]=".lock_overhead_cputime_percent"
+SHORT_HEADER[locks/wall_sec]=".total_lock_acquires_per_second"
+SHORT_HEADER[num_threads]=".num_threads"
+SHORT_HEADER[json]=".input_filename"
+SHORT_HEADER[host]=".hostname"
+SHORT_HEADER[lasom]=".lock_acquires_stddev_over_mean"
+
+# print SHORT_HEADER as a table
+if [[ $SORT_STRING == "help" ]]; then
+	(echo "sort_key sort_string";
+	for key in "${!SHORT_HEADER[@]}" ; do
+		echo "$key ${SHORT_HEADER[$key]}"
+	done) | column -t
+	exit -1
+fi
+
+if [[ -v SHORT_HEADER[$SORT_STRING] ]]; then
+	SORT_STRING="${SHORT_HEADER[$SORT_STRING]}"
+elif [[ ! $SORT_STRING =~ ^\. ]]; then
+	# we check for this to allow for complex multikey comma-separated sort string to be passed in as an argument.
+	echo "ERROR: SORT_STRING does not being with a . and is not one of the SHORT_HEADER keys, so it's probably not referring to a results variable."
+	exit -1
+fi
+
+#SORTER='sort_by(.cputime_ns_per_lock_acquire) '
+#SORTER='sort_by(.num_threads) '
+SORTER='sort_by('$SORT_STRING')'
+if [ $REVERSE -eq 1 ]; then
+	SORTER+=' | reverse'
+fi
+
+# json output from jq
+if [ $DUMP_DATA -eq 1 ]; then
+	exec jq -n -r "$REDUCER | $SELECTOR | $SORTER | . " $FILES
+fi
+
+
+# the rest of this is for the tabulated output
+
+# ----------------------------------
+# Construct KEY_LIST, an array defining the order of the columns.
+# These are typically keynames from entries in the .results[] of a json or, if there's a corresponding entry in SPECIAL_HEADER or SPECIAL_FILTER, what to show instead.
+# If the row begins with #, the metric is omitted.
+read -r -d '' -a KEY_LIST <<'EOF_KEY_LIST'
+test_name
+variant_name
+num_threads
+nominal_critical
+nominal_parallel
+cputime_ns_per_lock_acquire
+avg_critical_ns_per_loop
+avg_parallel_ns_per_loop
+avg_lock_overhead_cputime_ns
+lock_overhead_cputime_percent
+full_concurrency_fraction
+lock_acquires_stddev_over_mean
+host
+#json
+wall_elapsed_ns_per_lock_acquire
+total_lock_acquires_per_second
+EOF_KEY_LIST
+
+# SPECIAL_HEADER is what to print in the header for a key name. If the key does not exist, then the key name is used as the header.
+declare -A SPECIAL_HEADER
+SPECIAL_HEADER[cputime_ns_per_lock_acquire]="cpu_ns/lock"
+SPECIAL_HEADER[wall_elapsed_ns_per_lock_acquire]="wall_ns/lock"
+SPECIAL_HEADER[full_concurrency_fraction]="fcf"
+SPECIAL_HEADER[avg_parallel_ns_per_loop]="par_ns"
+SPECIAL_HEADER[avg_critical_ns_per_loop]="crit_ns"
+SPECIAL_HEADER[avg_lock_overhead_cputime_ns]="overhead_ns"
+SPECIAL_HEADER[lock_overhead_cputime_percent]="overhead_%"
+SPECIAL_HEADER[total_lock_acquires_per_second]="locks/wall_sec"
+SPECIAL_HEADER[lock_acquires_stddev_over_mean]="lasom"
+SPECIAL_HEADER[nominal_critical]="nom_crit"
+SPECIAL_HEADER[nominal_parallel]="nom_par"
+
+# SPECIAL_FILTER is how to have jq format the element. If the key does not exist, then .key is used for the filter.
+declare -A SPECIAL_FILTER
+SPECIAL_FILTER[cputime_ns_per_lock_acquire]='\(.cputime_ns_per_lock_acquire|round)'
+SPECIAL_FILTER[wall_elapsed_ns_per_lock_acquire]='\(.wall_elapsed_ns_per_lock_acquire|round)'
+SPECIAL_FILTER[full_concurrency_fraction]='\(.full_concurrency_fraction * 100 | round / 100)'
+SPECIAL_FILTER[host]='\(.hostname | split(".") | .[0])'
+SPECIAL_FILTER[json]='\(.input_filename | split(".") | .[:-1] | join("."))'
+SPECIAL_FILTER[avg_critical_ns_per_loop]='\(.avg_critical_ns_per_loop | round)'
+SPECIAL_FILTER[avg_parallel_ns_per_loop]='\(.avg_parallel_ns_per_loop | round)'
+SPECIAL_FILTER[avg_lock_overhead_cputime_ns]='\(.avg_lock_overhead_cputime_ns | round)'
+SPECIAL_FILTER[lock_overhead_cputime_percent]='\(.lock_overhead_cputime_percent | round)'
+SPECIAL_FILTER[total_lock_acquires_per_second]='\(.total_lock_acquires_per_second|round)'
+SPECIAL_FILTER[lock_acquires_stddev_over_mean]='\(.lock_acquires_stddev_over_mean*10000|round/10000)'
+
+# constructs the header or filter
+make_special() {
+local -n pointer="$1"		# name reference to associative array, needs bash 4.2 or later
+local normal_format_pre_eval=$2
+local normal_format
+local key
+local list=
+for key in "${KEY_LIST[@]}"
+do
+	if [[ $key =~ ^\# ]]; then
+		continue
+	fi
+	if [ -n "$list" ]; then
+		list="$list\t"
+	fi
+
+	normal_format=$(eval "echo \"$normal_format_pre_eval\"")
+
+	if [[ -v pointer[$key] ]]; then
+		list+="${pointer[$key]}"
+	else
+		list+=$normal_format
+	fi
+done
+echo "$list"
+}
+
+HEADER=$(make_special SPECIAL_HEADER '$key')
+FILTER=$(make_special SPECIAL_FILTER '\(.${key})')
+
+# ----------------------------------
+# finally invoke jq for tabulated output using 'column' to pretty print.
+(
+	echo -e "$HEADER"
+	jq -n -r "$REDUCER | $SELECTOR | $SORTER | .[] | \"$FILTER\" " $FILES
+) | column -t -o " "

--- a/benchmarks/lockhammer/src/alloc.c
+++ b/benchmarks/lockhammer/src/alloc.c
@@ -1,0 +1,338 @@
+
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <linux/mman.h>
+#include <sys/types.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "verbose.h"
+#include "alloc.h"
+#include "pagemap.h"
+
+typedef struct {
+    void * va;
+    uintptr_t pa;
+} hugepage_mapping_t;
+
+static void unmap_hugepage_mappings(hugepage_mapping_t * mappings, size_t n, size_t length) {
+    for (size_t i = 0; i < n; i++) {
+        void * va = mappings[i].va;
+        int ret = munmap(va, length);
+        if (ret == -1) {
+            fprintf(stderr, "ERROR: munmap(%p, %zu) failed!, i = %zu\n", va, length, i);
+            exit(-1);
+        }
+    }
+}
+
+void print_hugepage_physaddr_and_exit(void * mmap_ret) {
+    printf("0x%lx\n", get_phys_addr((uintptr_t) mmap_ret));
+    exit(0);
+}
+
+
+void * do_hugepage_alloc(int use_hugepages, size_t hugepage_req_physaddr, int verbose) {
+
+    size_t length;
+    int hugepage_size_flag; // will be set to the mmap flag specifying the hugepage size
+
+    switch (use_hugepages) {
+        case HUGEPAGES_DEFAULT:
+            // TODO: get the default hugepagesize from /proc/meminfo instead of hardcoding it here.
+            hugepage_size_flag = MAP_HUGE_2MB;
+            length = 2*1024ULL*1024ULL;
+            printf("INFO: assuming default hugepage size is 2MB!\n");
+            break;
+        case HUGEPAGES_64K:
+            hugepage_size_flag = MAP_HUGE_64KB;
+            length = 64*1024ULL;
+            break;
+        case HUGEPAGES_2M:
+            hugepage_size_flag = MAP_HUGE_2MB;
+            length = 2*1024ULL*1024ULL;
+            break;
+        case HUGEPAGES_32M:
+            hugepage_size_flag = MAP_HUGE_32MB;
+            length = 32*1024ULL*1024ULL;
+            break;
+        case HUGEPAGES_512M:
+            hugepage_size_flag = MAP_HUGE_512MB;
+            length = 512*1024ULL*1024ULL;
+            break;
+        case HUGEPAGES_1G:
+            hugepage_size_flag = MAP_HUGE_1GB;
+            length = 1024ULL*1024ULL*1024ULL;
+            break;
+        case HUGEPAGES_16G:
+            hugepage_size_flag = MAP_HUGE_16GB;
+            length = 16*1024ULL*1024ULL*1024ULL;
+            break;
+        default:
+            fprintf(stderr, "ERROR: shouldn't have gotten here!\n");
+            exit(-1);
+    }
+
+#define MAX_MMAP_TRIES 10
+
+    hugepage_mapping_t mmap_try[MAX_MMAP_TRIES];
+
+    for (size_t mmap_tries = 0; mmap_tries < MAX_MMAP_TRIES; mmap_tries++) {
+
+        // NOTE: mmap() will round-up length to the hugepage size
+        void * mmap_ret = mmap(NULL, length,
+                PROT_READ|PROT_WRITE,
+                MAP_PRIVATE|MAP_ANONYMOUS|MAP_HUGETLB|MAP_POPULATE|hugepage_size_flag,
+                -1, 0);
+
+        // if we got a hugepage mapping and we don't have a requested physaddr, we are done.
+        if (mmap_ret != MAP_FAILED && ! hugepage_req_physaddr) {
+            if (verbose >= VERBOSE_YES && geteuid() == 0) {
+                printf("INFO: hugepage physaddr = 0x%lx\n", get_phys_addr((uintptr_t) mmap_ret));
+            }
+            return mmap_ret;
+        }
+
+        // if we got a hugepage mapping..
+        if (mmap_ret != MAP_FAILED && hugepage_req_physaddr) {
+            size_t pa = get_phys_addr((uintptr_t) mmap_ret);
+            // printf("va = %p, pa = 0x%lx\n", mmap_ret, pa);
+            // .. and it matched, we are done.  unmap the previous attempts ones.
+            if (pa == hugepage_req_physaddr) {
+                // got the pa we wanted, so unmap the other mappings
+                unmap_hugepage_mappings(mmap_try, mmap_tries, length);
+                if (verbose >= VERBOSE_YES)
+                    printf("INFO: hugepage physaddr = 0x%lx\n", pa);
+                return mmap_ret;
+            }
+
+            // .. but if it was not the physaddr we wanted, remember the mapping
+            mmap_try[mmap_tries].va = mmap_ret;
+            mmap_try[mmap_tries].pa = pa;
+
+#if 0
+            printf("mmap_tries = %zu\n", mmap_tries);
+            for (size_t i = 0; i <mmap_tries; i++) {
+                printf("mmap_try[%zu].va = %lx, mmap_try[%zu].pa = %lx\n",
+                        i, (unsigned long) mmap_try[i].va, i, mmap_try[i].pa);
+            }
+#endif
+
+            continue;
+        }
+
+        // didn't get a hugepage mapping.
+        if (mmap_ret == MAP_FAILED) {
+            printf("mmap returned %p (MAP_FAILED). Exiting!\n"
+                    "Some possible reasons for failure:\n"
+                    " 1. no HugeTLB hugepage support is enabled,\n"
+                    " 2. no hugepages of the requested size are available,\n"
+                    " 3. the hugepage with the requested physaddr is already in use,\n"
+                    " 4. it is not available on a NUMA node available to us.\n"
+                    "Try:\n"
+                    " sudo apt-get install libhugetlbfs-bin\n"
+                    " sudo hugeadm --create-global-mounts\n"
+                    " sudo hugeadm --pool-pages-max DEFAULT:+1000\n"
+                    "(Only the last line is needed after a reboot.)\n"
+                    "Or manually allocate a hugepage:\n"
+                    "  echo 1 | sudo tee -a /sys/kernel/mm/hugepages/hugepages-%llukB/nr_hugepages\n"
+                    "Or use \"hugepagesz=<size> hugepage=<n>\" kernel parameters.\n",
+                    mmap_ret, length / 1024ULL);
+            exit(-1);
+        }
+
+        printf("ERROR: should not have gotten here!\n");
+        exit(-1);
+    }
+
+    printf("After %u tries, did not find the requested hugepage with physaddr = 0x%lx\n",
+            MAX_MMAP_TRIES, hugepage_req_physaddr);
+    unmap_hugepage_mappings(mmap_try, MAX_MMAP_TRIES, length);
+    exit(-1);
+
+    // satisfy the compiler
+    return NULL;
+}
+
+
+void * dynamic_lock_memory_base = NULL;
+
+// allocate memory, optionally using hugepages
+void * do_alloc(size_t length, int use_hugepages, size_t nonhuge_alignment, size_t hugepage_req_physaddr, int verbose) {
+
+    // XXX: length is erg_bytes * num_lock_memory_tries if not using hugepages
+    // if using hugepages, the implicit length will be 1 hugepage
+
+    if (use_hugepages != HUGEPAGES_NONE) {
+        return do_hugepage_alloc(use_hugepages, hugepage_req_physaddr, verbose);
+    }
+
+    // non-hugepage allocation
+
+    void * p;
+    int ret = posix_memalign((void **) &p, nonhuge_alignment, length);
+
+    if (ret) {
+        printf("posix_memalign returned %d, exiting\n", ret);
+        exit(-1);
+    }
+
+    // prefault
+    memset(p, 1, length);
+
+    dynamic_lock_memory_base = p;
+
+    return p;
+}
+
+static const struct {
+    const char * size_string;
+    const int enum_param_value;
+} hugepage_mapping[] = {
+    { "none", HUGEPAGES_NONE },
+    { "0", HUGEPAGES_NONE },
+    { "default", HUGEPAGES_DEFAULT },
+    { "1", HUGEPAGES_DEFAULT },
+    { "64K", HUGEPAGES_64K },
+    { "64KB", HUGEPAGES_64K },
+    { "2M", HUGEPAGES_2M },
+    { "2MB", HUGEPAGES_2M },
+    { "32M", HUGEPAGES_32M },
+    { "32MB", HUGEPAGES_32M },
+    { "512M", HUGEPAGES_512M },
+    { "512MB", HUGEPAGES_512M },
+    { "1G", HUGEPAGES_1G },
+    { "1GB", HUGEPAGES_1G },
+    { "16G", HUGEPAGES_16G },
+    { "16GB", HUGEPAGES_16G },
+};
+
+static const size_t num_hugepage_mappings = sizeof(hugepage_mapping) / sizeof(hugepage_mapping[0]);
+
+const char * hugepage_map (int enum_param_value) {
+    for (size_t i = 0; i < num_hugepage_mappings; i++) {
+        if (hugepage_mapping[i].enum_param_value == enum_param_value) {
+            return hugepage_mapping[i].size_string;
+        }
+    }
+    return NULL;
+}
+
+int parse_hugepage_parameter(const char * optarg) {
+    int use_hugepages = HUGEPAGES_NONE;
+    size_t i;
+
+    if (0 == strcasecmp(optarg, "help")) {
+        goto PRINT_HUGEPAGES;
+    }
+
+    // search for one of the strings in hugepage_mapping[]
+    for (i = 0; i < num_hugepage_mappings; i++) {
+        if (0 == strcasecmp(optarg, hugepage_mapping[i].size_string)) {
+            use_hugepages = hugepage_mapping[i].enum_param_value;
+            break;
+        }
+    }
+
+    // a string size_string was not found, parse for the enum value
+    if (i == num_hugepage_mappings) {
+        use_hugepages = strtoul(optarg, NULL, 0);
+    }
+
+    if (use_hugepages >= HUGEPAGES_MAX_ENUM || use_hugepages < HUGEPAGES_NONE) {
+        printf("Error: unknown hugepage parameter %s\n", optarg);
+PRINT_HUGEPAGES:
+        printf("param  hugepage size (may not be supported by the system!)\n");
+        for (i = 0; i < num_hugepage_mappings; i++) {
+            printf("%-5d  %s\n", hugepage_mapping[i].enum_param_value, hugepage_mapping[i].size_string);
+        }
+        exit(-1);
+    }
+
+    return use_hugepages;
+}
+
+
+uintptr_t get_phys_addr(uintptr_t vaddr) {
+
+    uintptr_t paddr = 0;
+
+    static unsigned long PAGESIZE = 1;
+    static unsigned long PAGE_MASK = 1;
+
+    static unsigned long last_vpage = 1;    // ensure mismatch
+    static unsigned long last_ppage = 1;
+
+    if (PAGESIZE == 1) {
+         PAGESIZE = sysconf(_SC_PAGESIZE);
+         PAGE_MASK = ~(PAGESIZE - 1);
+    }
+
+#if 0
+    pid_t pid = getpid();
+    printf("pid = %d, vaddr = %lx\n", pid, vaddr);
+    printf("vaddr & PAGE_MASK = %lx\n", vaddr & PAGE_MASK);
+    printf("last_vpage        = %lx\n", last_vpage);
+    printf("last_ppage        = %lx\n", last_ppage);
+#endif
+
+    if ((vaddr & PAGE_MASK) == last_vpage) {
+        return last_ppage | (vaddr & ~PAGE_MASK);
+    }
+
+    if (geteuid() == 0) {
+        pid_t pid = getpid();   // this process ID
+        if (lkmc_pagemap_virt_to_phys_user(&paddr, pid, vaddr)) {
+            fprintf(stderr, "error: virt_to_phys_user\n");
+            return EXIT_FAILURE;
+        }
+
+        last_vpage = vaddr & PAGE_MASK;
+        last_ppage = paddr & PAGE_MASK;
+
+        return paddr;
+    }
+
+    fprintf(stderr, "didn't expect to get here in get_phys_addr, not running as root?\n");
+    exit(-1);
+
+    return -1;
+}
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/src/args.c
+++ b/benchmarks/lockhammer/src/args.c
@@ -1,0 +1,618 @@
+
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "verbose.h"
+#include "lockhammer.h"
+#include "args.h"
+#include "alloc.h"
+
+
+
+static void new_print_usage (const char * invoc) {
+    fprintf(stderr,
+    "%s [args]\n"
+    "\n"
+    "processor affinity selection (pick one of either -t or -o):\n"
+    " -o | --pinning-order   n:[n:[n...]]          arbitrary CPU pinning order set, separated by comma, colon, or hard space\n"
+    "                                              A separate measurement will be conducted for each -o pinorder set.\n"
+    " -t | --num-threads           integer         number of worker threads to use\n"
+    " -i | --interleave-pinning    integer         number of hwthreads per core to algorithmically distribute worker threads using -t\n"
+    "    1: per-core pinning/no SMT, 2: 2-way SMT pinning, 4: 4-way SMT pinning, etc.; these modes will override the existing scheduler processor affinity mask\n"
+    "    0: enumerate CPUs from existing affinity mask\n"
+    " -C | --cpuorder-file         filename        for -t/--num-threads, allocate by CPU by number in order from this text file\n"
+    "\n"
+    "lock durations (at least one of both critical and parallel duration must be specified, and will be permuted):\n"
+    " -c | --critical              duration[ns|in] critical duration measured in nanoseconds (use \"ns\" suffix) or instructions (use \"in\" suffix; default is \"in\" if omitted)\n"
+    " -p | --parallel              duration[ns|in] parallel duration measured in nanoseconds (use \"ns\" suffix) or instructions (use \"in\" suffix; default is \"in\" if omitted)\n"
+    "--cn| --critical-nanoseconds  nanoseconds     upon acquiring a lock, duration to hold the lock (\"-c 1234ns\" equivalent)\n"
+    "--ci| --critical-instructions instructions    upon acquiring a lock, number of spin-loop instructions to run while holding the lock (\"-c 1234in\" equivalent)\n"
+    "--pn| --parallel-nanoseconds  nanoseconds     upon releasing a lock, duration to wait before attempting to reacquire the lock (\"-p 1234ns\" equivalent)\n"
+    "--pi| --parallel-instructions instructions    upon releasing a lock, number of spin-loop instructions to run while before attempting to reacquire the lock (\"-p 1234in\" equivalent)\n"
+    "\n"
+    "experiment iterations:\n"
+    " -n | --iterations            integer         number of times to run each measurement\n"
+    "\n"
+    "experiment length (work-based):\n"
+    " -a | --num-acquires          integer         number of acquires to do per thread\n"
+    "\n"
+    "experiment length (time-based):\n"
+    " -O | --run-limit-ticks       integer         each worker thread runs for this number of hardware timer ticks\n"
+    " -T | --run-limit-seconds     float_seconds   each worker thread runs for this number of seconds\n"
+    " -I | --run-limit-inner-iterations  integer   number of inner iterations of measurement between hardware timer polls\n"
+    "      --hwtimer-frequency     freq_hertz      Override HW timer frequency in Hertz instead of trying to determine it\n"
+    "      --estimate-hwtimer-frequency cpu_num    Estimate HW timer frequency on cpu_num\n"
+    "      --timeout-usecs         integer         kill benchmark if it exceeds this number of microseconds\n"
+    "\n"
+    "scheduler control:\n"
+    " -S | --scheduling-policy     FIFO|RR|OTHER   set explicit scheduling policy of created threads (may need root)\n"
+    "\n"
+    "memory placement control (hugepages):\n"
+    " -M | --hugepage-size  <integer|help|default> mmap hugepages of a size listed in \"-M help\"\n"
+    "      --print-hugepage-physaddr               print the physical address of the hugepage obtained, and then exit (must run as root)\n"
+    "      --hugepage-offset       integer         if --hugepage-size is used, the byte offset into the hugepage for the tests' lock\n"
+    "      --hugepage-physaddr     physaddr        obtain only the hugepage with the physaddr specified (must run as root)\n"
+    "\n"
+    "other:\n"
+#ifdef JSON_OUTPUT
+    "      --json filename                         save results to filename as a json\n"
+#endif
+//  "      --blackhole-numtries    integer         numtries for blackhole\n"  //undocumented
+    " -Y | --ignore-unknown-scaling-governor       do not exit as error if CPU scaling driver+governor is known bad/not known good\n"
+    " -Z | --suppress-cpu-frequency-warnings       suppress CPU frequecy scaling / governor warnings\n"
+#ifdef __aarch64__
+    "      --disable-outline-atomics-lse           disable use of LSE in outline atomics\n"
+#endif
+    " -v | --verbose                               print verbose messages\n"
+    "      --more-verbose                          print even more verbose messages\n"
+    "\n"
+    "lock-specific:\n"
+    " -- <workload-specific arguments>             lock-specific arguments are passed after --\n"
+    // TODO: provide lock-specific help message here
+    "\n"
+    , invoc);
+}
+
+
+// returns number of bytes per reservation granule (usually cache line length)
+static size_t get_ctr_erg_bytes(void) {
+#if defined(__aarch64__)
+    // Exclusive reservation granule ranges from 4 to 512 words.  Read from CTR_EL0.
+    size_t CTR, ERG, ERG_words;
+    asm volatile ("mrs %0, CTR_EL0" : "=r" (CTR));
+    ERG = (CTR >> 20) & 0xF;
+    if (ERG == 0) {
+        // According to Arm ARM, if CTR[ERG] == 0, assume 512 words (2KB)
+        ERG_words = 512;
+    } else {
+        ERG_words = 1 << ERG;
+    }
+    return ERG_words * 4;
+#elif defined(__x86_64__)
+    return 64;
+#else
+#error neither __aarch64__ nor __x86_64__ are defined in get_ctr_erg_bytes()
+#endif
+}
+
+
+// init_sysinfo - probe system configuration
+int init_sysinfo(system_info_t * psysinfo) {
+
+    // get the number of all possible processors
+    psysinfo->num_cores = sysconf(_SC_NPROCESSORS_CONF);
+    psysinfo->num_online_cores = sysconf(_SC_NPROCESSORS_ONLN);
+
+    // cache line size
+    psysinfo->erg_bytes = get_ctr_erg_bytes();
+
+    // page size
+    psysinfo->page_size_bytes = sysconf(_SC_PAGE_SIZE);
+
+    // sched_getaffinity() returns the affinity mask of the calling process,
+    // which are the CPUs it can be scheduled on, but that doesn't mean the
+    // CPU isn't online.  For example, isolcpus are online but not schedulable.
+
+    // get the set of schedulable processors allowed
+    CPU_ZERO(&psysinfo->avail_cores);
+
+    int ret = sched_getaffinity(0, sizeof(cpu_set_t), &psysinfo->avail_cores);
+    if (ret == -1) { perror("sched_getaffinity"); exit(EXIT_FAILURE); }
+
+    psysinfo->num_avail_cores = CPU_COUNT(&psysinfo->avail_cores);
+
+#if 0
+    // prints the CPUs on which that we can be scheduled
+    printf("scheduleable:");
+    for (size_t i = 0; i < psysinfo->num_cores; i++) {
+        if (CPU_ISSET(i, &psysinfo->avail_cores)) {
+            printf(" %zu", i);
+        } else {
+            printf(" !%zu", i);
+        }
+    }
+    printf("\n");
+#endif
+
+    return 0;
+}
+
+static int equals_in (const char * s) {
+    return (strcmp(s, "in") == 0);
+}
+
+static int equals_ns (const char * s) {
+    return (strcmp(s, "ns") == 0);
+}
+
+static int duration_parse_error (const char * endptr, const char * optarg) {
+    const int debug = 0;
+
+    if (*endptr) {
+        if (equals_ns(endptr) || equals_in(endptr)) {
+            if (optarg == endptr) {
+                if (debug) printf("ends with ns or in, but optarg == endptr (i.e. the whole optarg is \"ns\" or \"in\"), so error\n");
+                return 1;
+            }
+            if (debug) printf("ends with ns, so no error\n");
+            return 0;
+        }
+        if (debug) printf("does not end with ns, so error\n");
+        return 1;
+    }
+
+    if (debug) printf("endptr points to a null char, no error\n");
+    return 0;
+}
+
+static struct { const char * name; int value; } scheduling_policy_map[] = {
+    { "NOT SET", -1 },
+    { "FIFO", SCHED_FIFO },
+    { "RR", SCHED_RR },
+    { "OTHER", SCHED_OTHER },
+};
+
+static int parse_scheduling_policy(const char * optarg) {
+    size_t num_policies = sizeof(scheduling_policy_map) / sizeof(scheduling_policy_map[0]);
+    for (size_t i = 0; i < num_policies; i++) {
+        if (0 == strcasecmp(optarg, scheduling_policy_map[i].name)) {
+            printf("INFO: using explict scheduling policy %s\n", scheduling_policy_map[i].name);
+            return scheduling_policy_map[i].value;
+        }
+    }
+
+    fprintf(stderr, "ERROR: unknown scheduling policy %s\n", optarg);
+    exit(-1);
+    return -1; // shouldn't get here
+}
+
+extern char * optarg;
+extern int opterr;
+
+int parse_args(int argc, char ** argv, test_args_t * pargs, const system_info_t * psysinfo) {
+
+    enum {
+        longopt_hugepage_offset,
+        longopt_hugepage_physaddr,
+        longopt_print_hugepage_physaddr,
+        longopt_verbose,
+        longopt_timeout_usecs,
+        longopt_critical_instructions,
+        longopt_critical_nanoseconds,
+        longopt_parallel_instructions,
+        longopt_parallel_nanoseconds,
+        longopt_run_limit_seconds,
+#ifdef JSON_OUTPUT
+        longopt_json_filename,
+#endif
+        longopt_ignore_unknown_scaling_governor,
+        longopt_suppress_cpu_frequency_warnings,
+        longopt_hwtimer_frequency,
+        longopt_estimate_hwtimer_freq_cpu,
+        longopt_cpuorder_filename,
+        longopt_more_verbose,
+        longopt_blackhole_numtries,
+        longopt_disable_outline_atomics_lse,
+    };
+
+    static struct option long_options[] = {
+        // *name                has_arg             *flag       val (returned or stored thru *flag)
+        {"num-threads",         required_argument,  NULL,         't'},
+        {"cpuorder-file",       required_argument,  NULL,         longopt_cpuorder_filename},
+        {"critical-instructions", required_argument,NULL,         longopt_critical_instructions},
+        {"ci",                    required_argument,NULL,         longopt_critical_instructions},
+        {"critical-nanoseconds",  required_argument,NULL,         longopt_critical_nanoseconds},
+        {"cn",                    required_argument,NULL,         longopt_critical_nanoseconds},
+        {"parallel-instructions", required_argument,NULL,         longopt_parallel_instructions},
+        {"pi",                    required_argument,NULL,         longopt_parallel_instructions},
+        {"parallel-nanoseconds",  required_argument,NULL,         longopt_parallel_nanoseconds},
+        {"pn",                    required_argument,NULL,         longopt_parallel_nanoseconds},
+        {"critical",            required_argument,  NULL,         'c'},
+        {"parallel",            required_argument,  NULL,         'p'},
+        {"scheduling-policy",   required_argument,  NULL,         'S'},
+        {"interleave-pinning",  required_argument,  NULL,         'i'},
+        {"pinning-order",       required_argument,  NULL,         'o'},
+        {"iterations",          required_argument,  NULL,         'n'},
+        {"run-limit-ticks",     required_argument,  NULL,         'O'},
+        {"run-limit-seconds",   required_argument,  NULL,         longopt_run_limit_seconds},
+        {"run-limit-inner-iterations", required_argument, NULL,   'I'},
+        {"timeout-usecs",       required_argument,  NULL,         longopt_timeout_usecs},
+        {"hugepage-size",       required_argument,  NULL,         'M'},
+        {"hugepage-offset",     required_argument,  NULL,         longopt_hugepage_offset},
+        {"hugepage-physaddr",   required_argument,  NULL,         longopt_hugepage_physaddr},
+        {"print-hugepage-physaddr", no_argument,    NULL,         longopt_print_hugepage_physaddr},
+        {"num-acquires",        required_argument,  NULL,         'a'},
+#ifdef JSON_OUTPUT
+        {"json",                required_argument,  NULL,         longopt_json_filename},
+#endif
+        {"ignore-unknown-scaling-governor", no_argument, NULL,    longopt_ignore_unknown_scaling_governor},
+        {"suppress-cpu-frequency-warnings", no_argument, NULL,    longopt_suppress_cpu_frequency_warnings},
+        {"hwtimer-frequency",   required_argument,  NULL,         longopt_hwtimer_frequency},
+        {"estimate-hwtimer-frequency", required_argument, NULL,   longopt_estimate_hwtimer_freq_cpu},
+#ifdef __aarch64__
+        {"disable-outline-atomics-lse", no_argument,NULL,         longopt_disable_outline_atomics_lse},
+#endif
+        {"help",                no_argument,        NULL,         'h'},
+        {"verbose",             no_argument,        NULL,         longopt_verbose},
+        {"more-verbose",        no_argument,        NULL,         longopt_more_verbose},
+        {"blackhole-numtries",  required_argument,  NULL,         longopt_blackhole_numtries},
+        {0,                     0,                  NULL,         0}
+    };
+
+
+    char * this_arg = NULL; // point to the current string to be processed by getopt_long()
+    opterr = 0;
+
+    while (1) {
+        this_arg = argv[optind];
+        // printf("before getopt_long, argv[0] = %s, this_arg = argv[optind] = %s\n", argv[0], this_arg);
+        int opt = getopt_long(argc, argv, ":t:a:c:p:i:o:S:C:I:O:M:hn:T:vYZ", long_options, NULL);
+        long optval;
+        char * endptr = NULL;
+
+        // printf("after: opt = %d (%c), opterr = %d, this_arg = %s, next argv[optind] = %s\n", opt, opt, opterr, this_arg, argv[optind]);
+
+        if (opt == -1) {
+            // end of parsing
+            // printf("end of parsing on %s\n", this_arg);
+            break;
+        }
+
+        // FIXME: sanity check the values parsed by strtoul() and strtod(); examine endptr
+
+#define REALLOCARRAY(dest) \
+    if (!(pargs->dest = reallocarray(pargs->dest, pargs->num_##dest + 1, sizeof(pargs->dest[0])))) { \
+        fprintf(stderr, "ERROR: can't reallocate pargs->" stringify(dest) "on line " stringify(__LINE__) "\n"); exit(-1); }
+
+        switch (opt) {
+          case longopt_timeout_usecs:
+            pargs->timeout_usec = strtoul(optarg, NULL, 0);
+            break;
+          case 'a': // num_acquires
+            optval = strtoul(optarg, (char **) &endptr, 10);
+            if (!(*optarg != '\0' && *endptr == '\0')) {
+                fprintf(stderr, "ERROR: -a / --num-acquires argument '%s' is invalid\n", optarg);
+                return -1;
+            }
+            pargs->num_acquires = optval;
+            break;
+          case longopt_parallel_nanoseconds:
+          case longopt_parallel_instructions:
+            REALLOCARRAY(pars);
+            pargs->pars[pargs->num_pars].t = strtoul(optarg, (char **) NULL, 10);
+            pargs->pars[pargs->num_pars].unit = (opt == longopt_parallel_instructions) ? INSTS : NS;
+            pargs->num_pars++;
+            break;
+          case longopt_critical_nanoseconds:
+          case longopt_critical_instructions:
+            REALLOCARRAY(crits);
+            pargs->crits[pargs->num_crits].t = strtoul(optarg, (char **) NULL, 10);
+            pargs->crits[pargs->num_crits].unit = (opt == longopt_critical_instructions) ? INSTS : NS;
+            pargs->num_crits++;
+            break;
+          case 'c': // .hold, hold_unit ns or insts
+            optval = strtoul(optarg, &endptr, 10);
+
+            if (duration_parse_error(endptr, optarg)) {
+                fprintf(stderr, "ERROR: could not parse critical duration \"%s\" correctly\n", optarg);
+                return -1;
+            }
+
+            REALLOCARRAY(crits);
+            pargs->crits[pargs->num_crits].t = optval;
+            pargs->crits[pargs->num_crits].unit = equals_ns(endptr) ? NS : equals_in(endptr) ? INSTS : INSTS;
+            pargs->num_crits++;
+            break;
+          case 'p': // .post, .post_unit ns or insts
+            optval = strtoul(optarg, &endptr, 10);
+
+            if (duration_parse_error(endptr, optarg)) {
+                fprintf(stderr, "ERROR: could not parse parallel duration \"%s\" correctly\n", optarg);
+                return -1;
+            }
+
+            REALLOCARRAY(pars);
+            pargs->pars[pargs->num_pars].t = optval;
+            pargs->pars[pargs->num_pars].unit = equals_ns(endptr) ? NS : equals_in(endptr) ? INSTS : INSTS;
+            pargs->num_pars++;
+            break;
+          case 'i': // .ileave
+            pargs->ileave = strtoul(optarg, (char **) NULL, 10);
+            break;
+          case 'n': // --iterations
+            pargs->iterations = strtoul(optarg, (char **) NULL, 10);
+            break;
+          case 't': // number of threads using -t
+          case 'o': // pinorder - list the core numbers on which to run
+            {
+                // instead of iterating over cpu_set_t bitmaks,
+                // store in a temp array to preserve the order from -o pinorder
+
+                int * p = NULL;
+                size_t num_cpus_specified = 0;
+                int cpus_specified[psysinfo->num_cores];    // the index into this is the thread number, so the maximum number of elements is the maximum number of cores in the system.
+
+                if (opt == 'o') {
+
+                    cpu_set_t pinorder_specified_cores; // track if this -o pinorder has duplicate cpu
+                    CPU_ZERO(&pinorder_specified_cores);
+
+                    /* support comma, colon, and space as delimiter */
+                    const char * pinorder_delim = ",: ";
+                    char * csv = strtok(optarg, pinorder_delim);
+
+                    for (size_t i = 0; i < psysinfo->num_cores && csv != NULL; ++i) {
+                        int cpu = strtol(csv, (char **) NULL, 0);
+
+                        if (CPU_ISSET(cpu, &pinorder_specified_cores)) {
+                            fprintf(stderr, "ERROR: core number %d was previously specified in --pinning-order/-o pinorder list.  It must be specified only once.\n", cpu);
+                            exit(-1);
+                        }
+
+                        CPU_SET(cpu, &pinorder_specified_cores);
+                        cpus_specified[num_cpus_specified++] = cpu;
+                        csv = strtok(NULL, pinorder_delim);
+                    }
+
+                    p = malloc(sizeof(int) * num_cpus_specified); // XXX: this is never free'd
+
+                    if (!p) {
+                        fprintf(stderr, "ERROR: cannot allocate enough memory for pinorder structure.\n");
+                        return 1;
+                    }
+
+                    for (size_t i = 0; i < num_cpus_specified; i++) {
+                        p[i] = cpus_specified[i];
+                    }
+
+                } else {
+
+                    // -t num_threads
+
+                    num_cpus_specified = strtol(optarg, NULL, 0);
+
+                    if (num_cpus_specified > psysinfo->num_online_cores) {
+                        // TODO:  move this kind of validation out of arg parsing and into later arg validation phase
+                        fprintf(stderr, "ERROR: thread count must not be more than the number of online cores, %zu.\n", psysinfo->num_online_cores);
+                        exit(-1);
+                    }
+
+                    // for -t num_threads, the .cpu_list pointer is NULL to indicate that the arrangement is to be done later, i.e.:
+                    // pinorders[].cpu_list = NULL
+                    // pinorders[].num_threads = num_threads
+
+                }
+
+                REALLOCARRAY(pinorders);
+                pargs->pinorders[pargs->num_pinorders].cpu_list = p;
+                pargs->pinorders[pargs->num_pinorders].num_threads = num_cpus_specified;
+                pargs->num_pinorders++;
+            }
+            break;
+          case 'S':
+            pargs->scheduling_policy = parse_scheduling_policy(optarg);
+            break;
+          case 'T':
+          case longopt_run_limit_seconds:
+            pargs->run_limit_seconds = strtod(optarg, NULL);
+            break;
+          case 'O':
+            pargs->run_limit_ticks = strtoul(optarg, NULL, 0);
+            break;
+          case 'I':
+            pargs->run_limit_inner_loop_iters = strtoul(optarg, NULL, 0);
+            //printf("run_limit_inner_loop_iters = %lu\n", pargs->run_limit_inner_loop_iters);
+            break;
+          case 'M':     // -M has an op
+            pargs->use_mmap = 1;
+            //printf("optarg = %s, argv[optind] = %s\n", optarg, argv[optind]);
+            if (optarg) {   // e.g. -Mhelp
+                pargs->hugepagesz = parse_hugepage_parameter(optarg);
+            } else if (argv[optind]) {
+                if (argv[optind][0] == '-') {   // e.g. -M -nextflag => default
+                                                // argv[optind] is next flag
+                    pargs->hugepagesz = HUGEPAGES_DEFAULT;
+                } else if (argv[optind][0] != '\0') { // e.g. -M 2m => 2M
+                    pargs->hugepagesz = parse_hugepage_parameter(argv[optind]);
+                    optind++;
+                }
+            }
+            //printf("using mmap with hugepagesz = %s\n", hugepage_map(pargs->hugepagesz));
+            break;
+          case longopt_hugepage_offset:
+            // XXX: this offset is used for all of the locks for all of the hugepages, but this may not really be needed nor desired.
+            pargs->mmap_hugepage_offset_exists = 1;
+            pargs->mmap_hugepage_offset = strtoul(optarg, NULL, 0);
+            break;
+          case longopt_hugepage_physaddr:
+            // XXX: assume that physaddr 0 will never be the physical address of a hugepage
+            pargs->mmap_hugepage_physaddr = strtoul(optarg, NULL, 0);
+            break;
+          case longopt_print_hugepage_physaddr:
+            pargs->print_hugepage_physaddr = 1;
+            break;
+          case longopt_hwtimer_frequency:
+            pargs->hwtimer_frequency = strtoul(optarg, NULL, 0);
+            break;
+#ifdef JSON_OUTPUT
+          case longopt_json_filename:
+            pargs->json_output_filename = optarg;
+            break;
+#endif
+          case 'Y':
+          case longopt_ignore_unknown_scaling_governor:
+            pargs->ignore_unknown_scaling_governor = 1;
+            break;
+          case 'Z':
+          case longopt_suppress_cpu_frequency_warnings:
+            pargs->suppress_cpu_frequency_warnings = 1;
+            break;
+          case longopt_estimate_hwtimer_freq_cpu:
+            pargs->estimate_hwtimer_freq_cpu = optarg ? strtoul(optarg, NULL, 0) : 0;
+            break;
+          case 'C':
+          case longopt_cpuorder_filename:
+            pargs->cpuorder_filename = optarg;
+            break;
+          case longopt_more_verbose:
+            pargs->verbose = VERBOSE_MORE;
+            break;
+          case longopt_blackhole_numtries:
+            pargs->blackhole_numtries = strtoul(optarg, NULL, 0);
+            break;
+#ifdef __aarch64__
+          case longopt_disable_outline_atomics_lse:
+            pargs->disable_outline_atomics_lse = 1;
+            break;
+#endif
+          case 'v':
+          case longopt_verbose:
+            pargs->verbose = VERBOSE_YES;
+            break;
+          case '?':
+          case ':':
+            if (opt == '?')
+                printf("option flag %s is unknown\n\n", argv[optind-1]);
+            else if (opt == ':')
+                printf("option flag %s is missing an argument\n\n", argv[optind-1]);
+            // fall-through
+          case 'h':
+            new_print_usage(argv[0]);
+            exit(-1);
+        }
+    }
+
+    if (argc > optind && this_arg) {    // XXX: for --, optind is the first unknown arg or the first test argument (to the right of the --)
+        if (0 != strcmp(this_arg, "--")) {
+            fprintf(stderr, "ERROR: (main parser) unknown argument %s, opterr=%d\n", argv[optind], opterr);
+            exit(-1);
+        }
+
+        printf("INFO: There are test-specific args after the -- that will be processed later.\n");
+    }
+
+    return 0;
+}
+
+
+static void print_pinorder(const pinorder_t * p) {
+    size_t num_threads = p->num_threads;
+    printf("num_threads = %zu\n", num_threads);
+    if (p->cpu_list == NULL) {
+        printf("cpu_list not yet calculated\n");
+        return;
+    }
+    for (size_t i = 0; i < num_threads; i++) {
+        printf("[%zu] = %d\n", i, p->cpu_list[i]);
+    }
+}
+
+void print_test_args(const test_args_t * p) {
+    printf("test_args:\n");
+    printf("num_acquires = %lu\n", p->num_acquires);  // -a    number of acquires (not documented?)
+
+    printf("crits =");
+    for (size_t i = 0; i < p->num_crits; i++) {
+        printf(" %lu%s%c", p->crits[i].t, p->crits[i].unit == NS ? "ns" : "inst", (i == p->num_crits - 1) ? '\n' : ',');
+    }
+
+    printf("pars =");
+    for (size_t i = 0; i < p->num_pars; i++) {
+        printf(" %lu%s%c", p->pars[i].t, p->pars[i].unit == NS ? "ns" : "inst", (i == p->num_pars - 1) ? '\n' : ',');
+    }
+    printf("ileave = %lu\n", p->ileave);    // -i    interleave value for SMT pinning
+    printf("scheduling_policy = %d (%s)\n",
+            scheduling_policy_map[p->scheduling_policy].value,
+            scheduling_policy_map[p->scheduling_policy].name);
+
+    printf("cpuorder_filename = %s\n", p->cpuorder_filename);
+    printf("num_pinorders = %zu\n", p->num_pinorders);
+    for (size_t i = 0; i < p->num_pinorders; i++) {
+        if (p->pinorders[i].num_threads) {
+            printf("pinorder %zu\n", i);
+            print_pinorder(&(p->pinorders[i]));
+        }
+    }
+    printf("timeout_usec = %lu\n", p-> timeout_usec);
+    printf("hugepagesz = %d\n", p->hugepagesz);
+    printf("use_mmap = %d\n", p->use_mmap);
+    printf("mmap_hugepage_offset_exists = %d\n", p->mmap_hugepage_offset_exists);
+    printf("mmap_hugepage_offset = %zu\n", p->mmap_hugepage_offset);
+    printf("mmap_hugepage_physaddr = %p\n", (void *) p->mmap_hugepage_physaddr);
+    printf("hwtimer_frequency = %lu\n", p->hwtimer_frequency);
+    printf("estimate_hwtimer_freq_cpu = %ld\n", p->estimate_hwtimer_freq_cpu);
+
+    printf("run_limit_seconds = %f\n", p->run_limit_seconds);
+    printf("run_limit_ticks = %lu\n", p->run_limit_ticks);
+    printf("run_limit_inner_loop_iters = %lu\n", p->run_limit_inner_loop_iters);
+#ifdef JSON_OUTPUT
+    printf("json_output_filename = %s\n", p->json_output_filename);
+#endif
+    printf("ignore_unknown_scaling_governor = %d\n", p->ignore_unknown_scaling_governor);
+    printf("suppress_cpu_frequency_warnings = %d\n", p->suppress_cpu_frequency_warnings);
+    printf("verbose = %d\n", p->verbose);
+    printf("blackhole_numtries = %lu\n", p->blackhole_numtries);
+    printf("iterations = %zu\n", p->iterations);
+    printf("\n");
+}
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/src/cpufreq-scaling-detect.c
+++ b/benchmarks/lockhammer/src/cpufreq-scaling-detect.c
@@ -1,0 +1,330 @@
+
+/*
+ * Copyright (c) 2024-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "verbose.h"
+
+
+/*
+ * Check if the cpufreq driver and governor are acceptable configurations.
+ *
+ * A good configuration runs all CPUs at scaling_max_freq regardless of
+ * the number of threads (CPUs) active.
+ *
+ * A bad configuration reduces the CPU frequency based on load and then
+ * takes some time to return to a higher frequency.
+ *
+ * Dynamic CPU frequency scaling is a complicated subject because there are
+ * many different behaviors for driver and governor combinations.  These
+ * behaviors also vary by processor and platform, so the frequency behavior
+ * while under load must be examined using external analysis tools, such as
+ * "perf stat -e cycles -I 1000 -C $cpu taskset -c $cpu busy-loop-program".
+ *
+ * In any event, warn if "conservative" or "ondemand" is used.
+ */
+
+typedef struct {
+  const char * scaling_driver;
+  const char * scaling_governor;
+} scaling_t;
+
+scaling_t known_good_cpufreq_scalers[] = {
+  {.scaling_driver = "",             .scaling_governor = ""},  // for the case where there is no cpu scaling
+  {.scaling_driver = "cppc_cpufreq", .scaling_governor = "performance"},
+  {.scaling_driver = "acpi-cpufreq", .scaling_governor = "performance"},
+};
+
+scaling_t known_bad_cpufreq_scalers[] = {
+  {.scaling_driver = NULL,           .scaling_governor = "conservative"},
+  {.scaling_driver = NULL,           .scaling_governor = "ondemand"},
+};
+
+
+
+// get_proc_file_first_line - return the first line from the filename in a malloc'ed buffer, which must be free'd later
+static char * get_proc_file_first_line (const char * filename) {
+    FILE * f = fopen (filename, "r");
+    if (f == NULL) {
+//      system may not have cpufreq available
+//      fprintf(stderr, "couldn't open %s for reading\n", filename);
+        goto return_empty_string;
+    }
+
+    size_t line_len = 0;
+    char * line = NULL; // have getline mallocate a buffer
+    ssize_t nread;
+
+    while ((nread = getline(&line, &line_len, f)) != -1) {
+        //printf("nread = %zd, line_len = %zu, line = %s\n", nread, line_len, line);
+
+        // getline includes the newline if it was there
+        // nread includes the newline
+
+        if (nread == 0) {
+            break;
+        }
+
+        // strip newline if it exists
+        if (line[nread-1] == '\n') {
+            line[nread-1] = '\0';
+        }
+
+        fclose(f);
+        return line;
+    }
+
+    fprintf(stderr, "unexpectedly getline() returned -1 from reading %s\n", filename);
+
+    free(line);
+    fclose(f);
+
+return_empty_string:
+    line = malloc(1);
+    *line = '\0';
+    return line;
+}
+
+
+static char * get_scaling_string(unsigned long cpunum, const char * filename) {
+    char full_path[200];
+
+    int r = snprintf(full_path, sizeof(full_path),
+                 "/sys/devices/system/cpu/cpufreq/policy%lu/%s", cpunum, filename);
+
+    if (r >= sizeof(full_path)) {
+        fprintf(stderr, "couldn't construct full_path to read %s\n", filename);
+        exit(-1);
+    }
+
+    return get_proc_file_first_line(full_path);
+}
+
+static char * get_scaling_governor(unsigned long cpunum) {
+    return get_scaling_string(cpunum, "scaling_governor");
+}
+
+static char * get_scaling_driver(unsigned long cpunum) {
+    return get_scaling_string(cpunum, "scaling_driver");
+}
+
+static char * get_scaling_max_freq(unsigned long cpunum) {
+    return get_scaling_string(cpunum, "scaling_max_freq");
+}
+
+static char * get_scaling_min_freq(unsigned long cpunum) {
+    return get_scaling_string(cpunum, "scaling_min_freq");
+}
+
+static int get_boost_value(void) {
+    char * pc = get_proc_file_first_line("/sys/devices/system/cpu/cpufreq/boost");
+    long x = strtol(pc, NULL, 0);   // XXX: if pc is empty string (due to the boost file not existing) this will parse to 0.
+    free(pc);
+    return x;
+}
+
+// return 1 if found in scaling_list
+static int search_cpufreq_list(scaling_t * scaling_list, size_t list_len, char * scaling_driver, char * scaling_governor) {
+    for (size_t i = 0; i < list_len; i++) {
+        if (scaling_list[i].scaling_driver &&
+            strcmp(scaling_driver, scaling_list[i].scaling_driver)) {
+            continue;
+        }
+
+        if (scaling_list[i].scaling_governor &&
+            strcmp(scaling_governor, scaling_list[i].scaling_governor)) {
+            continue;
+        }
+
+        return 1;
+    }
+
+    return 0;
+}
+
+static int check_scaling_min_max_freq_are_equal(unsigned long cpunum, int ignore, int verbose, int suppress) {
+    char * scaling_min_freq = get_scaling_min_freq(cpunum);
+    char * scaling_max_freq = get_scaling_max_freq(cpunum);
+    int are_equal = 1;
+
+    if (strcmp(scaling_min_freq, scaling_max_freq)) {
+        are_equal = 0;
+        if (! suppress)
+            printf("%s: CPU %lu scaling_min_freq != scaling_max_freq (%s to %s)\n",
+                ignore? "WARNING" : "ERROR", cpunum, scaling_min_freq, scaling_max_freq);
+    } else if (verbose >= VERBOSE_MORE)
+        if (! suppress)
+            printf("%s: CPU %lu scaling_min_freq == scaling_max_freq (%s to %s)\n",
+                "INFO", cpunum, scaling_min_freq, scaling_max_freq);
+
+    free(scaling_min_freq);
+    free(scaling_max_freq);
+
+    return are_equal;
+}
+
+// returns 1 if OK, 0 if not
+int check_cpufreq_boost_is_OK(int ignore, int verbose, int suppress) {
+    // OK == boost is off
+
+    int boost = get_boost_value();
+    if (verbose >= VERBOSE_MORE) {
+        printf("boost = %d\n", boost);
+    }
+
+    if (0 == boost) {
+        return 1;
+    }
+
+    if (! suppress)
+        printf("%s: boost is enabled (value = %d), so CPU will adjust frequency based on load, which may affect performance.\n",
+            ignore ? "WARNING" : "ERROR", boost);
+    return ignore ? 1 : 0;
+}
+
+// returns 1 if OK, 0 if not
+int check_cpufreq_governor_is_OK_on_cpunum (unsigned long cpunum, int ignore, int verbose, int suppress) {
+    char * scaling_driver = get_scaling_driver(cpunum);
+    char * scaling_governor = get_scaling_governor(cpunum);
+
+    const size_t known_good_cpufreq_scalers_list_len = sizeof(known_good_cpufreq_scalers)/sizeof(known_good_cpufreq_scalers[0]);
+
+    if (search_cpufreq_list(known_good_cpufreq_scalers, known_good_cpufreq_scalers_list_len, scaling_driver, scaling_governor)) {
+        if (verbose >= VERBOSE_YES)
+            printf("found on CPU %lu scaling {driver=%s, governor=%s}\n",
+                    cpunum, scaling_driver, scaling_governor);
+        free(scaling_driver);
+        free(scaling_governor);
+
+        if (check_scaling_min_max_freq_are_equal(cpunum, ignore, verbose, suppress) || ignore) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    const size_t known_bad_cpufreq_scalers_list_len = sizeof(known_bad_cpufreq_scalers)/sizeof(known_bad_cpufreq_scalers[0]);
+
+    if (search_cpufreq_list(known_bad_cpufreq_scalers, known_bad_cpufreq_scalers_list_len, scaling_driver, scaling_governor)) {
+        if (! suppress)
+            printf("%s: On CPU %lu, cpu scaling {driver=%s, governor=%s} is known bad\n",
+                ignore ? "WARNING" : "ERROR", cpunum, scaling_driver, scaling_governor);
+        free(scaling_driver);
+        free(scaling_governor);
+        return 0;
+    }
+
+    // The intel_pstate driver's "performance" governor adjusts the frequency
+    // based on load.  This may be done by the operating system or autonomously
+    // by the processor itself.  Other cpufreq "performance" governors have the
+    // CPU run at or in between the scaling_min/max_freq limit parameters, and
+    // by setting them equal, the CPU should run at that freq.  However, with
+    // intel_pstate, setting the min/max frequency limits to be equal does not
+    // ensure that the CPU operates at that specific frequency.  For example, a
+    // CPU may run at an operating frequency lower than the min frequency if
+    // enough cores are active.
+
+    if ((0 == strcmp(scaling_driver, "intel_pstate"))) {
+        if (! suppress)
+            printf("%s: intel_pstate governor detected on CPU %lu may change frequency depending on the load\n",
+                ignore ? "WARNING" : "ERROR", cpunum);
+
+        if (check_scaling_min_max_freq_are_equal(cpunum, ignore, verbose, suppress)) {
+            if (! suppress)
+                printf("%s: intel_pstate CPU %lu frequency limits are equal, but the actual operating frequency may be autonomously determined by the hardware. Please check using perf stat!\n",
+                ignore ? "WARNING" : "ERROR", cpunum);
+        }
+
+        // Either way, we can't really do anything about it, other than inform which driver+governor is in use
+
+        free(scaling_driver);
+        free(scaling_governor);
+        return ignore;
+    }
+
+    if (! suppress)
+        printf("%s: On CPU %lu, cpu scaling {driver=%s, governor=%s} is not known good nor known bad\n",
+            ignore ? "WARNING" : "ERROR", cpunum, scaling_driver, scaling_governor);
+
+    // TODO: for {driver!=intel_pstate,governor=any} and {driver=intel_pstate,governor=any},
+    // check that scaling_max_freq and scaling_min_freq are equal so that frequency is not
+    // changed due to load.
+
+    free(scaling_driver);
+    free(scaling_governor);
+
+    return 0;
+}
+
+#ifdef TEST
+int is_scaling_governor(unsigned long cpunum, const char * expect_governor) {
+    char * governor_string = get_scaling_governor(cpunum);
+
+    if (governor_string) {
+        int retval = strcmp(governor_string, expect_governor);
+        free(governor_string);
+        return retval;
+    }
+
+    return 0;
+}
+
+int main (int argc, char ** argv) {
+
+    const char * expect_governor = "ondemand";
+    unsigned long cpunum = 0;
+
+    if (argc > 1) {
+        cpunum = strtoul(argv[1], NULL, 0);
+        if (argc > 2) {
+            expect_governor = argv[2];
+        }
+    }
+
+    if (is_scaling_governor(cpunum, expect_governor)) {
+        printf("scaling_governor for cpu%lu is %s\n", cpunum, expect_governor);
+    } else {
+        printf("scaling_governor for cpu%lu is not %s\n", cpunum, expect_governor);
+    }
+
+    char *test_string = get_proc_file_first_line("/proc/this-does-not-exist");
+    printf("test_string = %s, strlen = %zu\n", test_string, strlen(test_string));
+    free(test_string);
+
+    return 0;
+}
+#endif
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/src/lockhammer.c
+++ b/benchmarks/lockhammer/src/lockhammer.c
@@ -1,5 +1,6 @@
+
 /*
- * Copyright (c) 2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
  *
  * SPDX-License-Identifier:    BSD-3-Clause
  *
@@ -35,190 +36,821 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include <sys/mman.h>
+#include <linux/mman.h>
 #include <pthread.h>
 #include <sys/types.h>
 #include <time.h>
 #include <string.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <sys/time.h>
+#include <math.h>
+#include <locale.h>
+#include <signal.h>
+#include <assert.h>
 
+
+#include "args.h"
+#include "verbose.h"
 #include "lockhammer.h"
 #include "perf_timer.h"
+#include "alloc.h"
 
-#include ATOMIC_TEST
 
-uint64_t test_lock = 0;
-uint64_t sync_lock = 0;
-uint64_t calibrate_lock = 0;
-uint64_t ready_lock = 0;
+locks_t locks;
+
+#define handle_error_en(en, msg) \
+    do { errno = en; perror(msg); exit(EXIT_FAILURE); } while (0)
 
 void* hmr(void *);
 
-void print_usage (char *invoc) {
-    fprintf(stderr,
-            "Usage: %s\n\t[-t <#> threads]\n\t[-a <#> acquires per thread]\n\t"
-            "[-c <#>[ns | in] critical iterations measured in ns or (in)structions, "
-            "if no suffix, assumes instructions]\n\t"
-            "[-p <#>[ns | in] parallelizable iterations measured in ns or (in)structions, "
-            "if no suffix, assumes (in)structions]\n\t"
-            "[-s safe-mode operation for running as non-root by reducing priority]\n\t"
-            "[-i <#> interleave value for SMT pinning, e.g. 1: core pinning / no SMT, "
-            "2: 2-way SMT pinning, 4: 4-way SMT pinning, may not work for multisocket]\n\t"
-            "[-o <#:#:#:#> arbitrary pinning order separated by colon without space, "
-            "command lstopo can be used to deduce the correct order]\n\t"
-            "[-- <more workload specific arguments>]\n", invoc);
+#define MAXTHREADS 513
+
+pthread_t hmr_threads[MAXTHREADS];  // threads.
+
+per_thread_results_t per_thread_results[MAXTHREADS];
+
+unsigned long hwtimer_diff[MAXTHREADS];
+
+thread_args_t thread_args[MAXTHREADS];       // thread arguments, and results
+
+unsigned long cpu_order_count = 0;
+unsigned long cpu_order[MAXTHREADS];
+
+unsigned long hwtimer_frequency;
+
+uint64_t * p_other_lock_memory;     // for locks.p_ready_lock, p_sync_lock, p_calibrate_lock
+
+
+void disable_itimer (void);
+
+static unsigned long calculate_affinity(unsigned long thread_num, unsigned long num_cores, unsigned long ileave);
+void setup_hmr_attr (pthread_attr_t * p_hmr_attr, test_args_t * pargs);
+
+
+static unsigned long estimate_hwtimer_freq(long cpu_num);
+
+// src/cpufreq-scaling-detect.c
+int check_cpufreq_governor_is_OK_on_cpunum (unsigned long cpunum, int ignore, int verbose, int suppress);
+int check_cpufreq_boost_is_OK(int ignore, int verbose, int suppress);
+
+// in src/report.c:
+void standard_report (pinorder_t * p_pinorder, unsigned long meas_number, unsigned long test_number, unsigned long iteration, unsigned long wall_elapsed_ns, test_args_t * p_test_args, const duration_t * crit, const duration_t * par);
+void starting_stopping_time_report (unsigned long num_threads, unsigned long verbose, unsigned long num_acquires, pinorder_t * p_pinorder, unsigned long run_limit_ticks);
+void print_summary(test_args_t * args);
+
+// not really alarm, but itimer
+void main_alarm_handler (int x) {
+
+    size_t num_threads = thread_args[0].num_threads;
+
+    printf("main_alarm_handler called.  terminating %zu threads.\n", num_threads);
+
+    for (size_t i = 0; i < num_threads; i++) {
+        int s = pthread_cancel(hmr_threads[i]);
+        if (s) handle_error_en(x, "pthread_cancel");
+    }
 }
+
+struct sigaction main_alarm_sa = {
+    .sa_handler = main_alarm_handler,
+    .sa_mask = {{0}},
+    .sa_flags = 0
+};
+
+
+static int check_if_cpufreq_governors_of_pinorder_are_ok(const pinorder_t * p, int ignore, int verbose, int suppress);
+
+static void print_iteration_string(size_t iteration, size_t total_iterations,
+        unsigned long hold, Units hold_unit, unsigned long post,
+        Units post_unit, unsigned long pinorder_enum,
+        unsigned long num_threads, size_t measurement_counter,
+        size_t total_measurements, size_t test_counter, size_t total_tests, int verbose);
+
+
+static void run_one_experiment (test_args_t * args,
+        struct itimerval * deadline, unsigned long * p_start_ns,
+        pinorder_t * p_pinorder, unsigned long meas_number,
+        unsigned long test_number, unsigned long iteration,
+        const duration_t * crit, const duration_t * par);
+
+static int get_next_available_cpu (cpu_set_t * p_avail_cpus, int num_cores, int last_cpu_seen);
+
+
+static void print_system_info(system_info_t * p) {
+    printf(
+        "system_info:\n"
+        "  num_cores = %lu\n"
+        "  page_size_bytes = %zu\n"
+        "  erg_bytes = %zu\n"
+        "  CPU_COUNT(avail_cores) = %d\n"
+        "  num_avail_cores = %zu\n"
+        "  num_online_cores = %zu\n",
+        p->num_cores,
+        p->page_size_bytes,
+        p->erg_bytes,
+        CPU_COUNT(&p->avail_cores),
+        p->num_avail_cores,
+        p->num_online_cores
+    );
+}
+
+
+extern const char * test_name;
+extern const char * variant_name;
+
 
 int main(int argc, char** argv)
 {
-    struct sched_param sparam;
+    system_info_t sysinfo = {};
 
-    unsigned long opt;
-    unsigned long num_cores;
-    unsigned long result;
-    unsigned long sched_elapsed = 0, real_elapsed = 0, realcpu_elapsed = 0;
-    unsigned long start_ns = 0;
-    double avg_lock_depth = 0.0;
+    printf("Starting test_name=%s variant_name=%s\n", test_name, variant_name);
 
-    num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+    // init system info
+    init_sysinfo(&sysinfo);
+
+    const unsigned long num_avail_cores = sysinfo.num_avail_cores;    // the number of cpus that the affinity mask allows.
+
 
     /* Set defaults for all command line options */
-    test_args args = { .nthrds = num_cores,
-                       .nacqrs = 50000,
-                       .ncrit = 0,
-                       .nparallel = 0,
-                       .ileave = 1,
-                       .safemode = 0,
-                       .pinorder = NULL };
-
-    opterr = 0;
-
-    while ((opt = getopt(argc, argv, "t:a:c:p:i:o:s")) != -1)
+    test_args_t args =
     {
-        long optval = 0;
-        int len = 0;
-        char buf[128];
-        char *csv = NULL;
-        switch (opt) {
-          case 't':
-            optval = strtol(optarg, (char **) NULL, 10);
-            /* Do not allow number of threads to exceed online cores
-               in order to prevent deadlock ... */
-            if (optval < 0) {
-                fprintf(stderr, "ERROR: thread count must be positive.\n");
-                return 1;
-            }
-            else if (optval == 0) {
-                optval = num_cores;
-            }
-            else if (optval <= num_cores) {
-                args.nthrds = optval;
-            }
-            else {
-                fprintf(stderr, "WARNING: limiting thread count to online cores (%ld).\n", num_cores);
-            }
-            break;
-          case 'a':
-            optval = strtol(optarg, (char **) NULL, 10);
-            if (optval < 0) {
-                fprintf(stderr, "ERROR: acquire count must be positive.\n");
-                return 1;
-            }
-            else {
-                args.nacqrs = optval;
-            }
-            break;
-          case 'c':
-            // Set the units for loops
-            len = strlen(optarg);
-            if (optarg[len - 1] == 's') {
-                args.ncrit_units = NS;
-            } else {
-                args.ncrit_units = INSTS;
-            } 
-            
-            optval = strtol(optarg, (char **) NULL, 10);
-            if (optval < 0) {
-                fprintf(stderr, "ERROR: critical iteration count must be positive.\n");
-                return 1;
-            }
-            else {
-                args.ncrit = optval;
-            }
-            break;
-          case 'p':
-            // Set the units for loops
-            len = strlen(optarg);
-            if (optarg[len - 1] == 's') {
-                args.nparallel_units = NS;
-            } else {
-                args.nparallel_units = INSTS;
-            }
+        .num_acquires = 0,     // -a number of acquires
+        .crits = NULL,         // dynamic array of critical durations requested
+        .pars = NULL,          // dynamic array of parallel durations requested
+        .num_crits = 0,
+        .num_pars = 0,
+        .ileave = 0,         // -i
+        .scheduling_policy = 0,  // -S FIFO|RR|OTHER
+        .num_pinorders = 0,
+        .pinorders = NULL,      // -o
+        .timeout_usec = 0,
+        .hugepagesz = 0,
+        .use_mmap = 0,
+        .mmap_hugepage_offset = 0,
+        .mmap_hugepage_offset_exists = 0,
+        .print_hugepage_physaddr = 0,
+        .mmap_hugepage_physaddr = 0,
+        .hwtimer_frequency = 0,      // default=0 means to try to probe for it
+        .probed_hwtimer_frequency = 0,  // later on, if this is not 0, it means the value has been probed
+        .run_limit_ticks = 0,
+        .run_limit_seconds = 0,
+        .run_limit_inner_loop_iters = 10,
+#ifdef JSON_OUTPUT
+        .json_output_filename = NULL,
+#endif
+        .ignore_unknown_scaling_governor = 0,
+        .suppress_cpu_frequency_warnings = 0,
+        .estimate_hwtimer_freq_cpu = -1,
+#if defined(__aarch64__) && defined(USE_BUILTIN) && !defined(USE_LSE)
+        .disable_outline_atomics_lse = 0,
+#endif
+        .cpuorder_filename = NULL,
+        .verbose = VERBOSE_LOW,
+        .iterations = 1,
+        .blackhole_numtries = 15,
+    };
 
-            optval = strtol(optarg, (char **) NULL, 10);
-            if (optval < 0) {
-                fprintf(stderr, "ERROR: parallel iteration count must be positive.\n");
-                return 1;
-            }
-            else {
-                args.nparallel = optval;
-            }
-            break;
-          case 'i':
-            optval = strtol(optarg, (char **) NULL, 10);
-            if (optval < 0) {
-                fprintf(stderr, "ERROR: core interleave must be positive.\n");
-                return 1;
-            }
-            else {
-                args.ileave = optval;
-            }
-            break;
-          case 'o':
-            args.pinorder = calloc(num_cores, sizeof(int));
-            if (args.pinorder == NULL) {
-                fprintf(stderr, "ERROR: cannot allocate enough memory for pinorder structure.\n");
-                return 1;
-            }
-            /* support both comma and colon as delimiter */
-            csv = strtok(optarg, ",:");
-            for (int i = 0; i < num_cores && csv != NULL; ++i)
-            {
-                optval = strtol(csv, (char **) NULL, 10);
-                /* Some Arm systems may have core number larger than total cores number */
-                args.pinorder[i] = optval;
-                if (optval < 0 || optval > num_cores) {
-                    fprintf(stderr, "WARNING: core number %ld is out of range.\n", optval);
-                }
-                csv = strtok(NULL, ",:");
-            }
-            break;
-          case 's':
-            args.safemode = 1;
-            break;
-          case '?':
-          default:
-            print_usage(argv[0]);
-            return 1;
+    if (argc == 1) {
+        fprintf(stderr, "ERROR: no flags have been specified.  Use -h to see help.\n");
+        return -1;
+    }
+
+    if (parse_args(argc, argv, &args, &sysinfo)) {
+        return -1;
+    }
+
+    // call the test-specific argument parser, if it exists
+    measure_setup_parse_test_args(&args, argc, argv);
+
+    if (args.verbose >= VERBOSE_MORE) {
+        print_system_info(&sysinfo);
+        print_test_args(&args);
+    }
+
+#ifdef __aarch64__
+    if (args.disable_outline_atomics_lse) {
+        handle_disable_outline_atomics_lse();
+    }
+#endif
+
+    if (args.estimate_hwtimer_freq_cpu != -1) {
+        unsigned long freq = estimate_hwtimer_freq(args.estimate_hwtimer_freq_cpu);
+        printf("the estimated hwtimer frequency on CPU %ld in Hz is %lu\n", args.estimate_hwtimer_freq_cpu, freq);
+        return 0;
+    }
+
+    if (args.ileave) {
+
+        fprintf(stderr, "INFO: using interleaving mode with --interleave = %lu\n", args.ileave);
+
+        // num_cores = number of CPUs configured by the OS, basically all CPUs
+        // num_online_cores = getconf(_NPROCESSORS_ONLN) (includes online isolcpus)
+        // num_avail_cores = number of cores allowed by CPU affinity mask (excludes online isolcpus), basically CPU_COUNT(avail_cores)
+        // avail_cores = the CPU affinity mask
+
+        if (sysinfo.num_avail_cores != sysinfo.num_online_cores) {
+            // What we want to do is detect if there might be holes in the
+            // avail_cores schedmask because that may mean calculate_affinity()
+            // schedules onto a masked-off processor.  numactl --cpunodebind
+            // uses the modified CPU affinity mask to set affinity, which will
+            // also cause this warning to be printed.
+
+            fprintf(stderr, "WARNING: in interleaving mode, the number of available cores from processor affinity schedmask (%zu) does not equal the number of online cores (%zu)\n",
+                sysinfo.num_avail_cores, sysinfo.num_online_cores);
+        }
+
+        if (sysinfo.num_cores != sysinfo.num_online_cores) {
+            // This detects if there are CPUs that are offline on which
+            // calculate_affinity() may improperly try to place a thread.
+            fprintf(stderr, "WARNING: in interleaving mode, the number of configured cores (%zu) does not equal the number of online cores (%zu)\n",
+                sysinfo.num_cores, sysinfo.num_online_cores);
+        }
+
+    }
+
+
+    if (args.print_hugepage_physaddr) {
+        if (args.hugepagesz == HUGEPAGES_NONE) {
+            fprintf(stderr, "ERROR: --print-hugepage-physaddr requires a hugepage size to be specified using --hugepage-size.\n");
+            return -1;
+        }
+
+        if (geteuid() != 0) {
+            fprintf(stderr, "ERROR: --print-hugepage-physaddr must be run as root\n");
+            return -1;
+        }
+
+        void * hugepage_addr = do_hugepage_alloc(args.hugepagesz, args.mmap_hugepage_physaddr, args.verbose);
+        printf("0x%lx\n", get_phys_addr((uintptr_t) hugepage_addr));
+        return 0;
+    }
+
+
+    if (args.num_crits == 0) {
+        fprintf(stderr, "ERROR: no critical time is specified (use -c flag)\n");
+        return -1;
+    }
+
+    if (args.num_pars == 0) {
+        fprintf(stderr, "ERROR: no parallel time is specified (use -p flag)\n");
+        return -1;
+    }
+
+    if (args.run_limit_seconds && args.run_limit_ticks) {
+        printf("ERROR:  can't specify both --run-limit-seconds and --run-limit-ticks\n");
+        return -1;
+    }
+
+    if ((args.run_limit_seconds || args.run_limit_ticks) && args.num_acquires) {
+        printf("ERROR:  can't specify both --num-acquires and one of --run-limit-seconds or --run-limit-ticks\n");
+        return -1;
+    }
+
+    if (args.num_acquires == 0 && !(args.run_limit_seconds || args.run_limit_ticks)) {
+        printf("ERROR:  no -a/--num-acquires, -T/--run-limit-seconds, or -O/--run-limit-ticks flags were used, or had a value of 0\n");
+        return -1;
+    }
+
+    if (args.verbose >= VERBOSE_YES) {
+        printf("page_size_bytes = %zu\n", sysinfo.page_size_bytes);
+    }
+
+    if (args.verbose >= VERBOSE_YES) {
+        printf("Exclusive Reservation Granule size in bytes = %zu\n", sysinfo.erg_bytes);
+    }
+
+    if (args.mmap_hugepage_offset_exists && args.mmap_hugepage_offset % sysinfo.erg_bytes) {
+        printf("WARNING: mmap_hugepage_offset=%zu is not an exact multiple of erg_bytes=%zu.\n",
+            args.mmap_hugepage_offset, sysinfo.erg_bytes);
+    }
+
+    if (args.mmap_hugepage_physaddr) {
+        if (geteuid() != 0) {
+            printf("ERROR: --hugepage-physaddr must be run as root to validate the physical address obtained\n");
+            exit(-1);
+        }
+
+        if (! args.use_mmap) {
+            printf("ERROR: --hugepage-physaddr requires --hugepage-size to be specified\n");
+            exit(-1);
         }
     }
 
-    parse_test_args(args, argc, argv);
+    // try to determine hardware timer frequency through hardware or kernel-exposed means
+    if (args.hwtimer_frequency == 0) {
+        if (args.verbose >= VERBOSE_YES) printf("Determining timer frequency ...\n");
+        hwtimer_frequency = timer_get_timer_freq();
+        if (args.verbose >= VERBOSE_YES) printf("Found it as %lu Hz (which could be wrong, use --estimate-hwtimer-frequency to measure and --hwtimer-frequency to override)\n", hwtimer_frequency);
+        args.probed_hwtimer_frequency = hwtimer_frequency;
+    } else {
+        hwtimer_frequency = args.hwtimer_frequency;
+        if (args.verbose >= VERBOSE_YES) printf("Using HW timer frequency = %lu Hz from --hwtimer-frequency flag\n", hwtimer_frequency);
+    }
 
-    double tickspns;
-    pthread_t hmr_threads[args.nthrds];
+    // p_test_lock is the lock used for the performance measurement.
+
+    size_t alloc_length = MAXTHREADS * sysinfo.erg_bytes;
+
+    uint64_t * p_lock_memory = do_alloc(alloc_length, args.hugepagesz, sysinfo.erg_bytes,
+            args.mmap_hugepage_physaddr, args.verbose);
+
+    // XXX: there is no check that mmap_hugepage_offset doesn't go past
+    // alloc_length because hugepages may allocate more than requested so it is OK.
+    p_lock_memory += args.mmap_hugepage_offset / sizeof(uint64_t);
+
+    locks.p_test_lock      = p_lock_memory;
+
+
+    // p_calibrate_lock is the last of the locks for synchronization right before the start of the measurement.
+    p_other_lock_memory = aligned_alloc(sysinfo.erg_bytes, sysinfo.erg_bytes * 3);
+    if (p_other_lock_memory == NULL) {
+        fprintf(stderr, "could not allocate p_other_lock_memory\n"); exit (-1);
+    }
+
+    locks.p_ready_lock     = p_other_lock_memory;
+    locks.p_sync_lock      = p_other_lock_memory + 1 * (sysinfo.erg_bytes / (sizeof(uint64_t)));
+    locks.p_calibrate_lock = p_other_lock_memory + 2 * (sysinfo.erg_bytes / (sizeof(uint64_t)));
+
+    if (args.verbose >= VERBOSE_MORE) {
+        if (geteuid() == 0) {
+            // if root, we can show the physical address as well
+            printf("locks.p_test_lock      = %p, physaddr = %p\n", locks.p_test_lock      , (void *) get_phys_addr((uintptr_t) locks.p_test_lock));
+            printf("locks.p_ready_lock     = %p, physaddr = %p\n", locks.p_ready_lock     , (void *) get_phys_addr((uintptr_t) locks.p_ready_lock));
+            printf("locks.p_sync_lock      = %p, physaddr = %p\n", locks.p_sync_lock      , (void *) get_phys_addr((uintptr_t) locks.p_sync_lock));
+            printf("locks.p_calibrate_lock = %p, physaddr = %p\n", locks.p_calibrate_lock , (void *) get_phys_addr((uintptr_t) locks.p_calibrate_lock));
+        } else {
+            printf("locks.p_test_lock      = %p\n", locks.p_test_lock      );
+            printf("locks.p_ready_lock     = %p\n", locks.p_ready_lock     );
+            printf("locks.p_sync_lock      = %p\n", locks.p_sync_lock      );
+            printf("locks.p_calibrate_lock = %p\n", locks.p_calibrate_lock );
+        }
+    }
+
+
+    // Get frequency of hwtimer, and divide by 1B to get # of ticks per ns
+    uint64_t counter_frequency = timer_get_timer_freq();
+
+    if (args.verbose >= VERBOSE_MORE)
+        printf("counter_frequency = %lu, args.hwtimer_frequency = %lu\n", counter_frequency, args.hwtimer_frequency);
+
+    double ticks_per_ns = counter_frequency / 1000000000.0;
+
+
+    // run limit is the expected duration to run for.
+
+    double run_limit_seconds = 0;
+
+    if (args.run_limit_seconds) {
+        run_limit_seconds = args.run_limit_seconds;
+        args.run_limit_ticks = run_limit_seconds * counter_frequency;
+        if (args.verbose >= VERBOSE_YES)
+            printf("run_limit_ticks = %lu, at %lu Hz, estimated from --run-limit-seconds %f\n",
+                    args.run_limit_ticks, counter_frequency, run_limit_seconds);
+    } else if (args.run_limit_ticks) {
+        run_limit_seconds = args.run_limit_ticks / (double) counter_frequency;
+        if (args.verbose >= VERBOSE_YES)
+            printf("--run-limit-ticks %lu, at %lu Hz, is estimated to take %f seconds\n",
+                    args.run_limit_ticks, counter_frequency, run_limit_seconds);
+    } else {
+        if (args.verbose >= VERBOSE_YES)
+            printf("--num-acquires %lu per thread\n", args.num_acquires);
+    }
+
+
+    // --timeout-usecs is the deadline, the maximum allowed time to run for.
+
+    struct itimerval deadline = {
+        .it_interval = { .tv_sec = 0, .tv_usec = 0 },
+        .it_value = { .tv_sec = 0, .tv_usec = 0 }       // time until next expiration
+    };
+
+    if (args.timeout_usec) {
+        // convert usec into sec.usec
+        deadline.it_value.tv_sec = args.timeout_usec / 1000000;
+        deadline.it_value.tv_usec = args.timeout_usec % 1000000;
+        printf("setitimer timeout = --timeout-usecs %lu   ---> %lu.%06lu seconds\n",
+            args.timeout_usec,
+            deadline.it_value.tv_sec,
+            deadline.it_value.tv_usec);
+    }
+
+    if (args.run_limit_ticks && args.timeout_usec) {
+        double deadline_it_value_sec = deadline.it_value.tv_sec + deadline.it_value.tv_usec * 1e-6;
+        if (deadline_it_value_sec < run_limit_seconds) {
+            printf("WARNING: setitimer timeout is shorter than run_limit_ticks, so the benchmark will end before the specified duration from -O/--run-limit-ticks\n");
+        }
+    }
+
+    // read CPU ordering list
+    if (args.cpuorder_filename) {
+        FILE * f = fopen(args.cpuorder_filename, "r");
+        if (!f) { fprintf(stderr, "ERROR: cannot open file %s\n", args.cpuorder_filename); exit(-1); }
+        while (! feof(f)) {
+            unsigned long cpu_number;
+            int n = fscanf(f, "%lu", &cpu_number);
+            if (n != 1) {
+                if (feof(f)) {
+                    break;
+                }
+                printf("ERROR: from %s, token %lu, didn't get expected number of elements and is not eof, instead got n = %d\n", args.cpuorder_filename, cpu_order_count, n);
+                exit(-1);
+            }
+            cpu_order[cpu_order_count++] = cpu_number;
+        }
+        fclose(f);
+
+        if (args.verbose >= VERBOSE_YES) {
+            printf("cpu_order from %s, length = %zu\nindex\tcpu\n", args.cpuorder_filename, cpu_order_count);
+            for (size_t i = 0; i < cpu_order_count; i++) {
+                printf("%zu\t%lu\n", i, cpu_order[i]);
+            }
+        }
+    }
+
+    // create a pinorder of all CPUs if no -o pinorder / -t num_threads was given
+    if (args.num_pinorders == 0) {
+
+        fprintf(stderr, "INFO: setting thread count to the number of available cores (%zu).\n", num_avail_cores);
+
+        if (args.verbose >= VERBOSE_YES)
+            printf("processing -t flag for %zu threads with -i %lu interleave\n", num_avail_cores, args.ileave);
+
+        args.num_pinorders = 1;
+        assert(args.pinorders == NULL);
+        args.pinorders = malloc(sizeof(args.pinorders[0]));
+        args.pinorders[0].num_threads = num_avail_cores;
+        args.pinorders[0].cpu_list = NULL;
+    }
+
+    // generate cpu_list if it isn't already made
+    for (size_t i = 0; i < args.num_pinorders; i++) {
+
+        pinorder_t * po = &(args.pinorders[i]);
+
+        if (po->num_threads == 0) {             // "-t 0" was given on command line
+            po->num_threads = num_avail_cores;  // number of threads allowed by sched mask
+        }
+
+        // global data structures are sized using MAXTHREADS
+        if (po->num_threads > MAXTHREADS) {
+            fprintf(stderr, "ERROR: po->num_threads=%zu is greater than MAXTHREADS=%u\n"
+                "Increase the value of MAXTHREADS in lockhammer.c and recompile.\n",
+                po->num_threads, MAXTHREADS);
+            exit(-1);
+        }
+
+        if (po->cpu_list != NULL) {
+            continue;
+        }
+
+        // For any -t num_threads flags, generate a pinorder cpu_list
+        po->cpu_list = malloc(sizeof(po->cpu_list[0]) * po->num_threads);
+        if (po->cpu_list == NULL) {
+             fprintf(stderr, "ERROR: can't allocate memory for a pinorder CPU list\n");
+             exit(-1);
+        }
+
+        if (args.ileave) {
+            // NOTE: This is calculated using sysinfo.num_cores (all CPUs configured by OS)
+            // which can result in a placement on an offline CPU/not allowed by affinity mask.
+            for (size_t j = 0; j < po->num_threads; j++) {
+                po->cpu_list[j] = calculate_affinity(j, sysinfo.num_cores, args.ileave);
+            }
+        } else if (cpu_order_count) {
+            // For -t num_threads, but allocated in the order from cpuorder_filename
+            // This will not place on CPUs that are not available in the sysinfo.avail_cores mask
+            int cpu_order_index = 0;
+
+            for (size_t j = 0; j < po->num_threads; j++) {
+                int found = 0;
+                do {
+                    int cpu_candidate = cpu_order[cpu_order_index++];
+                    if (CPU_ISSET(cpu_candidate, &sysinfo.avail_cores)) {
+                        po->cpu_list[j] = cpu_candidate;
+                        found = 1;
+                    } else if (cpu_order_index >= cpu_order_count) {
+                        fprintf(stderr, "ERROR: no CPU is available after assigning %zu CPUs\n", j);
+                        exit(-1);
+                    }
+                } while (! found);
+            }
+        } else {
+            // For -t num_threads allocated in CPU numerical order of sysinfo.avail_cores mask.
+            int cpu = -1;
+            for (size_t j = 0; j < po->num_threads; j++) {
+                cpu = get_next_available_cpu(&sysinfo.avail_cores, sysinfo.num_cores, cpu);
+                if (cpu == -1) {
+                    fprintf(stderr, "ERROR: no CPU is available after assigning %zu CPUs\n", j);
+                    exit(-1);
+                }
+                po->cpu_list[j] = cpu;
+            }
+        }
+
+        if (args.verbose >= VERBOSE_YES) {
+            printf("thread-to-cpu assignment for pinorder number %zu:", i);
+            for (size_t j = 0; j < po->num_threads; j++) {
+                printf(" %zu->%d", j, po->cpu_list[j]);
+            }
+            printf("\n");
+        }
+
+    }
+
+
+    // check if boost is enabled
+
+    if (! check_cpufreq_boost_is_OK(args.ignore_unknown_scaling_governor, args.verbose, args.suppress_cpu_frequency_warnings)) {
+        if (! args.ignore_unknown_scaling_governor) {
+            fprintf(stderr, "ERROR: boost is enabled, but --ignore-unknown-scaling-governor / -Y was NOT set.  Aborting!\n");
+            exit(-1);
+        }
+        if (! args.suppress_cpu_frequency_warnings) {
+            fprintf(stderr, "WARNING: boost is enabled, but --ignore-unknown-scaling-governor / -Y was specified, so continuing anyway!\n");
+        }
+    }
+
+
+    // for each defined pinorder, run one experiment.
+
+    // if there are any pinorders with num_threads > 0, run them
+
+    if (! args.pinorders[0].num_threads) {
+        fprintf(stderr, "ERROR: no pinorders have been defined! This should never happen!\n");
+        exit(-1);
+    }
+
+    if (args.verbose >= VERBOSE_YES)
+        printf("processing pinorders\n");
+
+    // check all pinorders' CPUs' frequency scaling setting
+
+    int a_pinorder_failed = 0;
+
+    for (size_t i = 0; i < args.num_pinorders; i++) {
+        pinorder_t * p = &(args.pinorders[i]);
+        a_pinorder_failed |= ! check_if_cpufreq_governors_of_pinorder_are_ok(p, args.ignore_unknown_scaling_governor, args.verbose, args.ignore_unknown_scaling_governor);
+    }
+
+    if (a_pinorder_failed) {
+        if (! args.ignore_unknown_scaling_governor) {
+            fprintf(stderr, "ERROR: At least one pinorder's CPU frequency scaling setting has issues, but --ignore-unknown-scaling-governor / -Y was NOT set.  Aborting!\n");
+            exit(-1);
+        }
+        if (! args.suppress_cpu_frequency_warnings) {
+            fprintf(stderr, "WARNING: At least one pinorder's CPU frequency scaling setting has issues, but --ignore-unknown-scaling-governor / -Y was specified, so continuing anyway!\n");
+        }
+    }
+
+    size_t total_measurements = 0;
+    size_t measurement_counter = 0;
+    size_t total_tests = 0;
+    size_t test_counter = 0;
+
+    for (size_t ipinorder = 0; ipinorder < args.num_pinorders; ipinorder++) {
+    for (size_t icrit = 0; icrit < args.num_crits; icrit++) {
+    for (size_t ipar = 0; ipar < args.num_pars; ipar++) {
+        total_tests++;
+    for (size_t iteration = 1; iteration <= args.iterations; iteration++) {
+        total_measurements++;
+    }
+    }
+    }
+    }
+
+
+    for (size_t ipinorder = 0; ipinorder < args.num_pinorders; ipinorder++) {
+        pinorder_t * p = &(args.pinorders[ipinorder]);
+    for (size_t icrit = 0; icrit < args.num_crits; icrit++) {
+    for (size_t ipar = 0; ipar < args.num_pars; ipar++) {
+        unsigned long crit = args.crits[icrit].t;
+        unsigned long par = args.pars[ipar].t;
+        Units crit_unit = args.crits[icrit].unit;
+        Units par_unit = args.pars[ipar].unit;
+
+        test_counter++;
+        for (size_t iteration = 1; iteration <= args.iterations; iteration++) {
+            unsigned long start_ns = 0;
+            measurement_counter++;
+            print_iteration_string(iteration, args.iterations, crit, crit_unit, par, par_unit, ipinorder, p->num_threads, measurement_counter, total_measurements, test_counter, total_tests, args.verbose);
+
+            for (size_t i = 0; i < p->num_threads; i++) {
+                thread_args[i].thread_num = i;
+                thread_args[i].num_threads = p->num_threads;
+                thread_args[i].num_acquires = args.num_acquires;
+                thread_args[i].lock = locks.p_test_lock;    // this is the main lock.
+
+                thread_args[i].p_start_ns = &start_ns;      // only marshal thread sets this.
+                thread_args[i].hold = crit;
+                thread_args[i].post = par;
+                thread_args[i].hold_unit = crit_unit;
+                thread_args[i].post_unit = par_unit;
+                thread_args[i].tickspns = ticks_per_ns;
+
+                thread_args[i].run_on_this_cpu = p->cpu_list[i];
+                thread_args[i].run_limit_ticks = args.run_limit_ticks;
+                thread_args[i].run_limit_inner_loop_iters = args.run_limit_inner_loop_iters;
+                thread_args[i].results.cpu_affined = 0;  // XXX should this line exist since results is just output?
+
+                thread_args[i].hwtimer_frequency = hwtimer_frequency;
+
+                thread_args[i].verbose = args.verbose;
+                thread_args[i].blackhole_numtries = args.blackhole_numtries;
+            }
+
+            run_one_experiment(&args, &deadline, &start_ns, p, measurement_counter, test_counter, iteration, &args.crits[icrit], &args.pars[ipar]);
+        }
+    }
+    }
+    }
+
+    // clear iteration string line
+    if (args.verbose == VERBOSE_LOW)
+        fprintf(stdout, "\33[2K\r");
+
+    print_summary(&args);
+
+    // clean up all malloc'd memory
+    extern void * dynamic_lock_memory_base;
+    if (dynamic_lock_memory_base) {
+        free(dynamic_lock_memory_base);
+    }
+
+    if (p_other_lock_memory) {
+        free(p_other_lock_memory);
+    }
+
+    // TODO: the heap memory allocated by in the test's initialize_lock() is not released.
+
+    free(args.crits);
+    free(args.pars);
+    for (size_t i = 0; i < args.num_pinorders; i++) {
+        free(args.pinorders[i].cpu_list);
+    }
+    free(args.pinorders);
+    return 0;
+}
+
+
+static void run_one_experiment (test_args_t * args,
+        struct itimerval * deadline, unsigned long * p_start_ns,
+        pinorder_t * p_pinorder, unsigned long meas_number,
+        unsigned long test_number, unsigned long iteration,
+        const duration_t * crit, const duration_t * par)
+{
+    unsigned long num_threads = p_pinorder->num_threads;
+
+    *p_start_ns = 0;
+
     pthread_attr_t hmr_attr;
-    unsigned long hmrs[args.nthrds];
-    unsigned long hmrtime[args.nthrds]; /* can't touch this */
-    unsigned long hmrrealtime[args.nthrds];
-    unsigned long hmrdepth[args.nthrds];
-    struct timespec tv_time;
+    setup_hmr_attr(&hmr_attr, args);
+
+    long thread_return_code[num_threads];
+    for (size_t i = 0; i < num_threads; i++) {
+        thread_return_code[i] = 0;
+    }
+
+    // TODOs for being able to rerun with different pinorder and thread count
+    // TODO: one-time blackhole calibration optional
+    // TODO: save/restore thread scheduling affinity after an experiment
+
+    // ensure that locks are cleared before reuse
+    *(locks.p_test_lock) = 0;
+    *(locks.p_sync_lock) = 0;
+    *(locks.p_calibrate_lock) = 0;
+    *(locks.p_ready_lock) = 0;
+
+    measure_setup_initialize_lock(&locks, p_pinorder);
+
+    // ------ time is somewhat important starting here ------
+
+    if (args->run_limit_ticks || args->timeout_usec) {
+        setitimer(ITIMER_REAL, deadline, NULL);
+        sigaction(SIGALRM, &main_alarm_sa, NULL);
+    }
+
+    // launch threads
+    for (size_t i = 0; i < num_threads; ++i) {
+        int s = pthread_create(&hmr_threads[i], &hmr_attr, hmr, (void*)(&thread_args[i]));
+        if (s)
+             handle_error_en(s, "pthread_create");
+    }
+
+    // wait for threads
+    for (size_t i = 0; i < num_threads; ++i) {
+        void * pthread_exit_status = (void *) &(thread_return_code[i]);
+        int s = pthread_join(hmr_threads[i], &pthread_exit_status);
+        if (s)
+             handle_error_en(s, "pthread_join");
+        if (pthread_exit_status == PTHREAD_CANCELED) {
+            printf("thread %zu was cancelled, lock_acquires = %lu\n", i, thread_args[i].results.lock_acquires);
+            thread_return_code[i] = 0;
+        }
+    }
+
+    /* "Marshal" thread will collect start time once all threads have
+        reported ready so we only need to collect the end time here */
+    struct timespec wall_time_end;
+    clock_gettime(CLOCK_MONOTONIC, &wall_time_end);
+
+    // ------ time is important ending here ------
+
+    disable_itimer();
+
+    if (args->verbose >= VERBOSE_YES)
+    printf("Measurement completed.\n");
+
+    if (args->verbose >= VERBOSE_MORE)
+        for (size_t i = 0; i < num_threads; i++) {
+            printf("thread_return_code[%zu] = %ld\n", i, thread_return_code[i]);
+        }
+
+    // wall_elapsed_ns is the wallclock time from when the marshal thread
+    // started its measurement until the clock_gettime() a few lines above.
+    // These are measured by separate processes so the assumption is
+    // clock_gettime(CLOCK_MONOTONIC) returns a true wall clock time.
+
+    unsigned long wall_elapsed_ns = timespec_to_ns(&wall_time_end) - *p_start_ns;
+
+    // report results
+
+    standard_report(p_pinorder, meas_number, test_number, iteration, wall_elapsed_ns, args, crit, par);
+    starting_stopping_time_report(num_threads, args->verbose, args->num_acquires, p_pinorder, args->run_limit_ticks);
+
+    pthread_attr_destroy(&hmr_attr);
+
+    return;
+}
+
+static unsigned long calculate_affinity(unsigned long thread_num, unsigned long num_cores, unsigned long ileave) {
+
+    /*
+     * The concept of "interleave" is used here to allow for specifying
+     * whether increasing cores counts first populate physical cores or
+     * hardware threads within the same physical core. This assumes the
+     * following relationship between logical core numbers (N), hardware
+     * threads per core (K), and physical cores (N/K):
+     *
+     *  physical core |___core_0__|___core_1__|_core_N/K-1|
+     *         thread |0|1|...|K-1|0|1|...|K-1|0|1|...|K-1|
+     *  --------------|-|-|---|---|-|-|---|---|-|-|---|---|
+     *   logical core | | |   |   | | |   |   | | |   |   |
+     *              0 |*| |   |   | | |   |   | | |   |   |
+     *              1 | | |   |   |*| |   |   | | |   |   |
+     *            ... |...................................|
+     *          N/K-1 | | |   |   | | |   |   |*| |   |   |
+     *            N/K | |*|   |   | | |   |   | | |   |   |
+     *          N/K+1 | | |   |   | |*|   |   | | |   |   |
+     *            ... |...................................|
+     *            N-K | | |   | * | | |   |   | | |   |   |
+     *          N-K+1 | | |   |   | | |   | * | | |   |   |
+     *            ... |...................................|
+     *            N-1 | | |   |   | | |   |   | | |   | * |
+     *
+     * Thus by setting the interleave value to 1 physical cores are filled
+     * first with subsequent cores past N/K adding subsequent threads
+     * on already populated physical cores.  On the other hand, setting
+     * interleave to K causes the algorithm to populate 0, N/K, 2N/K and
+     * so on filling all hardware threads in the first physical core prior
+     * to populating any threads on the second physical core.
+     */
+
+    if (thread_num >= num_cores) {
+        // the code below does not assign to threads correctly if the number of threads to assign is greater than the number of cores.
+        fprintf(stderr, "ERROR: unexpectedly thread_num >= num_cores in calculate_affinity().\n");
+        exit(-1);
+    }
+
+    unsigned long threads_per_core = ileave;
+    unsigned long thread_offset = 0;
+    unsigned long base_core = 0;
+
+    for (unsigned long i = 0; i < thread_num; i++) {
+        base_core += threads_per_core;
+        if (base_core >= num_cores) {
+            base_core = 0;
+            thread_offset++;
+        }
+    }
+
+    unsigned long target_core = base_core + thread_offset;
+
+    return target_core;
+}
+
+
+
+
+void setup_hmr_attr (pthread_attr_t * p_hmr_attr, test_args_t * pargs) {
 
     /* Select the FIFO scheduler.  This prevents interruption of the
-       lockhammer test threads allowing for more precise measuremnet of
+       lockhammer test threads allowing for more precise measurement of
        lock acquisition rate, especially for mutex type locks where
        a lock-holding or queued thread might significantly delay forward
-       progress if it is rescheduled.  Additionally the FIFO scheduler allows
+       progress if it is rescheduled.  Additionally, the FIFO scheduler allows
        for a better guarantee of the requested contention level by ensuring
        that a fixed number of threads are executing simultaneously for
        the duration of the test.  This comes at the significant cost of
@@ -229,256 +861,159 @@ int main(int argc, char** argv)
        no more than a few milliseconds and lockhammer should never be run
        on an already-deplayed system. */
 
-    pthread_attr_init(&hmr_attr);
-    if (!args.safemode) {
-        pthread_attr_setinheritsched(&hmr_attr, PTHREAD_EXPLICIT_SCHED);
-        pthread_attr_setschedpolicy(&hmr_attr, SCHED_FIFO);
-        sparam.sched_priority = 1;
-        pthread_attr_setschedparam(&hmr_attr, &sparam);
-    }
+    int s = pthread_attr_init(p_hmr_attr);
+    if (s) handle_error_en(s, "pthread_attr_init");
 
-    initialize_lock(&test_lock, num_cores);
-    // Get frequency of clock, and divide by 1B to get # of ticks per ns
-    tickspns = (double)timer_get_cnt_freq() / 1000000000.0; 
-
-    thread_args t_args[args.nthrds];
-    for (int i = 0; i < args.nthrds; ++i) {
-        hmrs[i] = 0;
-        t_args[i].ncores = num_cores;
-        t_args[i].nthrds = args.nthrds;
-        t_args[i].ileave = args.ileave;
-        t_args[i].iter = args.nacqrs;
-        t_args[i].lock = &test_lock;
-        t_args[i].rst = &hmrs[i];
-        t_args[i].nsec = &hmrtime[i];
-        t_args[i].real_nsec = &hmrrealtime[i];
-        t_args[i].depth = &hmrdepth[i];
-        t_args[i].nstart = &start_ns;
-        t_args[i].hold = args.ncrit;
-        t_args[i].hold_unit = args.ncrit_units;
-        t_args[i].post = args.nparallel;
-        t_args[i].post_unit = args.nparallel_units;
-        t_args[i].tickspns = tickspns;
-        t_args[i].pinorder = args.pinorder;
-
-        pthread_create(&hmr_threads[i], &hmr_attr, hmr, (void*)(&t_args[i]));
-    }
-
-    for (int i = 0; i < args.nthrds; ++i) {
-        result = pthread_join(hmr_threads[i], NULL);
-    }
-    /* "Marshal" thread will collect start time once all threads have
-        reported ready so we only need to collect the end time here */
-    clock_gettime(CLOCK_MONOTONIC, &tv_time);
-    real_elapsed = (1000000000ul * tv_time.tv_sec + tv_time.tv_nsec) - start_ns;
-
-    pthread_attr_destroy(&hmr_attr);
-
-    result = 0;
-    for (int i = 0; i < args.nthrds; ++i) {
-        result += hmrs[i];
-        sched_elapsed += hmrtime[i];
-        realcpu_elapsed += hmrrealtime[i];
-        /* Average lock "depth" is an algorithm-specific auxiliary metric
-           whereby each algorithm can report an approximation of the level
-           of contention it observes.  This estimate is returned from each
-           call to lock_acquire and accumulated per-thread.  These results
-           are then aggregated and averaged here so that an overall view
-           of the run's contention level can be determined. */
-        avg_lock_depth += ((double) hmrdepth[i] / (double) hmrs[i]) / (double) args.nthrds;
-    }
-
-    fprintf(stderr, "%ld lock loops\n", result);
-    fprintf(stderr, "%ld ns scheduled\n", sched_elapsed);
-    fprintf(stderr, "%ld ns elapsed (~%f cores)\n", real_elapsed, ((float) sched_elapsed / (float) real_elapsed));
-    fprintf(stderr, "%lf ns per access (scheduled)\n", ((double) sched_elapsed)/ ((double) result));
-    fprintf(stderr, "%lf ns per access (real)\n", ((double) realcpu_elapsed)/ ((double) result));
-    fprintf(stderr, "%lf ns access rate\n", ((double) real_elapsed) / ((double) result));
-    fprintf(stderr, "%lf average depth\n", avg_lock_depth);
-
-    printf("%ld, %f, %lf, %lf, %lf, %lf\n",
-           args.nthrds,
-           ((float) sched_elapsed / (float) real_elapsed),
-           ((double) sched_elapsed)/ ((double) result),
-           ((double) realcpu_elapsed)/ ((double) result),
-           ((double) real_elapsed) / ((double) result),
-           avg_lock_depth);
-
-    return 0;
-}
-
-/* Calculate timer spin-times where we do not access the clock.  
- * First calibrate the wait loop by doing a binary search around 
- * an estimated number of ticks. All threads participate to take
- * into account pipeline effects of threading.
- */
-static void calibrate_timer(thread_args *x, unsigned long mycore)
-{
-    if (x->hold_unit == NS) {
-        /* Determine how many timer ticks would happen for this wait time */
-        unsigned long hold = (unsigned long)((double)x->hold * x->tickspns);
-        /* Calibrate the number of loops we have to do */
-        x->hold = calibrate_blackhole(hold, 0, TOKENS_MAX_HIGH, mycore);
-    } else {
-        x->hold = x->hold / 2;
-    }
-
-    // Make sure to re-sync any stragglers
-    synchronize_threads(&calibrate_lock, x->nthrds);
-
-    if (x->post_unit == NS) {
-        unsigned long post = (unsigned long)((double)x->post * x->tickspns);
-        x->post = calibrate_blackhole(post, 0, TOKENS_MAX_HIGH, mycore);
-    } else {
-        x->post = x->post / 2;
-    }
-#ifdef DEBUG
-    printf("Calibrated (%lu) with hold=%ld post=%ld\n", mycore, x->hold, x->post);
-#endif
-}
-
-void* hmr(void *ptr)
-{
-    unsigned long nlocks = 0;
-    thread_args *x = (thread_args*)ptr;
-
-    unsigned long *lock = x->lock;
-    unsigned long target_locks = x->iter;
-    unsigned long ncores = x->ncores;
-    unsigned long ileave = x->ileave;
-    unsigned long nthrds = x->nthrds;
-    unsigned long hold_count = x->hold;
-    unsigned long post_count = x->post;
-    double tickspns = x->tickspns;
-    int *pinorder = x->pinorder;
-
-    unsigned long mycore = 0;
-
-    struct timespec tv_monot_start, tv_monot_end, tv_start, tv_end;
-    unsigned long ns_elap, real_ns_elap;
-    unsigned long total_depth = 0;
-
-    cpu_set_t affin_mask;
-
-    CPU_ZERO(&affin_mask);
-
-    /* Coordinate synchronized start of all lock threads to maximize
-       time under which locks are stressed to the requested contention
-       level */
-    mycore = fetchadd64_acquire(&sync_lock, 2) >> 1;
-
-    if (mycore == 0) {
-        /* First core to register is a "marshal" who waits for subsequent
-           cores to become ready and starts all cores with a write to the
-           shared memory location */
-
-        /* Set affinity to core 0 */
-        CPU_SET(0, &affin_mask);
-        sched_setaffinity(0, sizeof(cpu_set_t), &affin_mask);
-
-        /* Spin until the appropriate numer of threads have become ready */
-        wait64(&ready_lock, nthrds - 1);
-        fetchadd64_release(&sync_lock, 1);
-
-        calibrate_timer(x, mycore);
-        hold_count = x->hold;
-        post_count = x->post;
-
-        /* Wait for all threads to arrive from calibrating. */ 
-        synchronize_threads(&calibrate_lock, nthrds);
-    } else {
-        /*
-         * Non-zero core value indicates next core to pin, zero value means
-         * fallback to default interleave mode. Note: -o and -i may have
-         * conflicting pinning order that causes two or more threads to pin
-         * on the same core. This feature interaction is intended by design
-         * which allows 0 to serve as don't care mask and only changing the
-         * pinning order we want to change for specific -i interleave mode.
-         */
-        if (pinorder && pinorder[mycore]) {
-            CPU_SET(pinorder[mycore], &affin_mask);
-            sched_setaffinity(0, sizeof(cpu_set_t), &affin_mask);
-        } else { /* Calculate affinity mask for my core and set affinity */
-            /*
-             * The concept of "interleave" is used here to allow for specifying
-             * whether increasing cores counts first populate physical cores or
-             * hardware threads within the same physical core. This assumes the
-             * following relationship between logical core numbers (N), hardware
-             * threads per core (K), and physical cores (N/K):
-             *
-             *  physical core |___core_0__|___core_1__|_core_N/K-1|
-             *         thread |0|1|...|K-1|0|1|...|K-1|0|1|...|K-1|
-             *  --------------|-|-|---|---|-|-|---|---|-|-|---|---|
-             *   logical core | | |   |   | | |   |   | | |   |   |
-             *              0 |*| |   |   | | |   |   | | |   |   |
-             *              1 | | |   |   |*| |   |   | | |   |   |
-             *            ... |...................................|
-             *          N/K-1 | | |   |   | | |   |   |*| |   |   |
-             *            N/K | |*|   |   | | |   |   | | |   |   |
-             *          N/K+1 | | |   |   | |*|   |   | | |   |   |
-             *            ... |...................................|
-             *            N-K | | |   | * | | |   |   | | |   |   |
-             *          N-K+1 | | |   |   | | |   | * | | |   |   |
-             *            ... |...................................|
-             *            N-1 | | |   |   | | |   |   | | |   | * |
-             *
-             * Thus by setting the interleave value to 1 physical cores are filled
-             * first with subsequent cores past N/K adding subsequent threads
-             * on already populated physical cores.  On the other hand, setting
-             * interleave to K causes the algorithm to populate 0, N/K, 2N/K and
-             * so on filling all hardware threads in the first physical core prior
-             * to populating any threads on the second physical core.
-             */
-            CPU_SET(((mycore * ncores / ileave) % ncores + (mycore / ileave)), &affin_mask);
-            sched_setaffinity(0, sizeof(cpu_set_t), &affin_mask);
+    // if root and a policy is set thru -S, apply it; otherwise, don't change it.
+    if (pargs->scheduling_policy) {
+        if (0 != getuid()) {
+            fprintf(stderr, "ERROR: need to be root to use -S/--scheduling-policy flag\n");
+            exit(-1);
         }
 
-        fetchadd64_release(&ready_lock, 1);
-
-        /* Spin until the "marshal" sets the appropriate bit */
-        wait64(&sync_lock, (nthrds * 2) | 1);
-
-        /* All threads participate in calibration */
-        calibrate_timer(x, mycore);
-        hold_count = x->hold;
-        post_count = x->post;
-
-        /* Wait for all threads to arrive from calibrating */
-        synchronize_threads(&calibrate_lock, nthrds);
-    }
-
-    thread_local_init(mycore);
-
-#ifdef DDEBUG
-    printf("%ld %ld\n", hold_count, post_count);
+#if 0
+        int policy;
+        struct sched_param current_sched_param;
+        s = pthread_getschedparam(pthread_self(), &policy, &current_sched_param);
+        if (s) handle_error_en(s, "pthread_getschedparam");
+        printf("policy = %d, current_sched_param.sched_priority = %d\n",
+                policy, current_sched_param.sched_priority);
 #endif
 
-    clock_gettime(CLOCK_MONOTONIC, &tv_monot_start);
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_start);
+        s = pthread_attr_setinheritsched(p_hmr_attr, PTHREAD_EXPLICIT_SCHED);
+        if (s) handle_error_en(s, "pthread_attr_setinheritsched");
 
-    while (!target_locks || nlocks < target_locks) {
-        /* Do a lock thing */
-        prefetch64(lock);
-        total_depth += lock_acquire(lock, mycore);
-        blackhole(hold_count);
-        lock_release(lock, mycore);
-        blackhole(post_count);
+        // SCHED_FIFO, SCHED_RR, and SCHED_OTHER (OTHER is 0)
+        s = pthread_attr_setschedpolicy(p_hmr_attr, pargs->scheduling_policy);
+        if (s) handle_error_en(s, "pthread_attr_setschedpolicy");
 
-        nlocks++;
+        struct sched_param sparam = { .sched_priority = 1 };
+        s = pthread_attr_setschedparam(p_hmr_attr, &sparam);
+        if (s) handle_error_en(s, "pthread_attr_setschedparam");
     }
-    clock_gettime(CLOCK_MONOTONIC, &tv_monot_end);
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_end);
-
-    if (mycore == 0)
-        *(x->nstart) = (1000000000ul * tv_monot_start.tv_sec + tv_monot_start.tv_nsec);
-
-    ns_elap = (1000000000ul * tv_end.tv_sec + tv_end.tv_nsec) - (1000000000ul * tv_start.tv_sec + tv_start.tv_nsec);
-    real_ns_elap = (1000000000ul * tv_monot_end.tv_sec + tv_monot_end.tv_nsec) - (1000000000ul * tv_monot_start.tv_sec + tv_monot_start.tv_nsec);
-
-    *(x->rst) = nlocks;
-    *(x->nsec) = ns_elap;
-    *(x->real_nsec) = real_ns_elap;
-    *(x->depth) = total_depth;
-
-    return NULL;
 }
+
+
+
+void disable_itimer (void) {
+
+    // disable interval timer by setting it to 0
+    struct itimerval disable_timer = {
+        .it_interval = { .tv_sec = 0, .tv_usec = 0 },
+        .it_value = { .tv_sec = 0, .tv_usec = 0 }
+    };
+
+    setitimer(ITIMER_REAL, &disable_timer, NULL);    // XXX: check return value
+}
+
+
+static unsigned long estimate_hwtimer_freq(long cpu_num) {
+
+    unsigned long n = 10;
+    unsigned long hwtimer_start, hwtimer_stop, hwtimer_diff;
+    unsigned long hwtimer_average = 0;
+
+    printf("Estimating HW timer frequency on CPU %ld for %lu iterations\n", cpu_num, n);
+
+    cpu_set_t cpu_mask;
+
+    CPU_ZERO(&cpu_mask);
+    CPU_SET(cpu_num, &cpu_mask);
+
+    if (0 != sched_setaffinity(0, sizeof(cpu_mask), &cpu_mask)) {
+        perror("sched_setaffinity");
+        exit(-1);
+    }
+
+    for (unsigned long i = 0; i < n; i++) {
+
+        struct timeval ts_a, ts_b, ts_diff;
+
+        hwtimer_start = get_raw_counter();
+        gettimeofday(&ts_a, NULL);
+
+        do {
+            gettimeofday(&ts_b, NULL);
+            timersub(&ts_b, &ts_a, &ts_diff);
+        } while (ts_diff.tv_sec < 1);
+
+        hwtimer_stop = get_raw_counter();
+
+        hwtimer_diff = hwtimer_stop - hwtimer_start;
+
+        printf("hwtimer_diff = %lu\n", hwtimer_diff);
+
+        hwtimer_average += hwtimer_diff;
+    }
+
+    hwtimer_average /= (double) n;
+
+    // printf("hwtimer_average = %lu\n", hwtimer_average);
+
+    return hwtimer_average;
+}
+
+static int check_if_cpufreq_governors_of_pinorder_are_ok(const pinorder_t * p, int ignore, int verbose, int suppress) {
+    // XXX: this checks CPUs reused between pinorders multiple times
+    int all_ok = 1;
+    for (size_t i = 0; i < p->num_threads; ++i) {
+        // check_cpufreq_governor_is_OK_on_cpunum() returns 0 if the CPU p->pinorder[i] is not OK
+        all_ok &= check_cpufreq_governor_is_OK_on_cpunum(p->cpu_list[i], ignore, verbose, suppress);
+    }
+    return all_ok;
+}
+
+const char * unit_to_string[] = {
+    [NS] = "ns",
+    [INSTS] = "inst",
+    [NOT_SET] = "not set"   // should never be able to print this
+};
+
+static void print_iteration_string(size_t iteration, size_t total_iterations,
+        unsigned long hold, Units hold_unit, unsigned long post,
+        Units post_unit, unsigned long pinorder_enum,
+        unsigned long num_threads, size_t measurement_counter,
+        size_t total_measurements, size_t test_counter, size_t total_tests, int verbose) {
+
+    // at this point, an iteration line has been printed on a prior call, or this is the first and none have been printed yet.
+
+    if (verbose < VERBOSE_LOW) return;
+
+    // ONLY in VERBOSE_LOW mode, clear the line and reset the cursor to the row start
+    if (verbose == VERBOSE_LOW)
+        fprintf(stdout, "\33[2K\r");
+    else
+        printf("\n");
+
+    if (verbose >= VERBOSE_YES)
+        printf("---------------------------------------------------------------------------------\n");
+
+    fprintf(stdout, "measurement %zu/%zu (test %zu/%zu iteration %zu/%zu), critical=%lu%s parallel=%lu%s, pinorder=%lu num_threads=%lu",
+        measurement_counter, total_measurements, test_counter, total_tests, iteration, total_iterations,
+        hold, unit_to_string[hold_unit], post, unit_to_string[post_unit], pinorder_enum, num_threads);
+
+    // ONLY in VERBOSE_LOW mode, force the printing of the iteration string without a newline
+    if (verbose == VERBOSE_LOW)
+        fflush(stdout);
+    else
+        fprintf(stdout, "\n");
+
+    if (verbose >= VERBOSE_YES)
+        printf("---------------------------------------------------------------------------------\n");
+}
+
+static int get_next_available_cpu (cpu_set_t * p_avail_cpus, int num_cores, int last_cpu_seen) {
+    int cpu = last_cpu_seen + 1;
+
+    for (; cpu < num_cores; cpu++) {
+        if (CPU_ISSET(cpu, p_avail_cpus)) {
+            //printf("found cpu=%d to be available\n", cpu);
+            return cpu;
+        }
+    }
+
+    return -1;
+}
+
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/src/measure.c
+++ b/benchmarks/lockhammer/src/measure.c
@@ -1,0 +1,812 @@
+
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <stdio.h>
+#include <time.h>
+#include <pthread.h>
+#include <limits.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <linux/mman.h>
+
+#include "alloc.h"
+#include "verbose.h"
+#include "lockhammer.h"
+#include "atomics.h"
+#include "perf_timer.h"
+
+
+extern locks_t locks;
+
+unsigned long timespec_to_ns (struct timespec * ts) {
+    return 1000000000ULL * ts->tv_sec + ts->tv_nsec;
+}
+
+void dump_mem(void * p, size_t n) {
+    char * pc = (char *) p;
+    printf("n = %zu\n", n);
+    for (size_t i = 0; i < n; i++) {
+            printf("%02X ", 0xFF & pc[i]);
+            if ((i % 16) == 15) {
+                printf("\n");
+            }
+    }
+    printf("\n");
+}
+
+#ifdef __aarch64__
+// The --disable-outline-atomics-lse flag is only relevant to tests built
+// using USE_BUILTIN=1 USE_LSE=0 such that the __atomics intrinsics are
+// implemented by the compiler as a function call to the corresponding
+// routine in libgcc, which will use the load-exclusive/store-exclusive
+// instructions instead of the LSE instructions.
+
+// If USE_BUILTIN=0, then lockhammer's own assembly routines are used in
+// the measurement.  (The other non-measurement uses of the routines in the
+// harness will still call the libgcc routines.)
+
+// If USE_LSE=1, then -march=armv8-a+lse is passed to the compiler when
+// compiling measure.c for the test, and it will emit inlined assembly
+// using LSE instructions, so this flag will not be effective for the
+// measurement because the libgcc routines are not called.
+// (Non-measurement uses will cal the libgcc routines.)
+
+// This function must be here because the USE_* macros now only affect the
+// compilation of measure.c and included test, while the rest of the lockhammer
+// harness is built for a generic target.
+
+void handle_disable_outline_atomics_lse(void) {
+#if defined(USE_BUILTIN) && !defined(USE_LSE)
+    extern unsigned char __aarch64_have_lse_atomics;
+    __aarch64_have_lse_atomics = 0;
+    fprintf(stderr, "INFO: --disable-outline-atomics-lse turned off using LSE in outline atomics\n");
+#else
+    fprintf(stderr, "ERROR: --disable-outline-atomics-lse only applies to build variant USE_BUILTIN=1 and USE_LSE=0\n");
+    exit(-1);
+#endif
+}
+#endif
+
+#ifndef TEST_NAME
+#define TEST_NAME unknown_test_name
+#endif
+const char * test_name = stringify(TEST_NAME);
+
+#ifndef VARIANT_NAME
+#define VARIANT_NAME unknown_variant_name
+#endif
+const char * variant_name = stringify(VARIANT_NAME);
+
+
+
+#include ATOMIC_TEST
+
+#ifndef initialize_lock
+    #define initialize_lock(p_lock, p_pinorder, num_thread)
+#endif
+#ifndef parse_test_args
+    #define parse_test_args(args, argc, argv)
+#endif
+#ifndef thread_local_init
+    #define thread_local_init(smtid)
+#endif
+
+
+
+// call the test-specific lock initialization routine
+void measure_setup_initialize_lock (locks_t * p_locks, pinorder_t * p_pinorder) {
+    // p_test_lock is passed to here thru p_locks
+    // TODO: list which algorithms actually use it (most do not and just take num_cores)
+    // XXX: do any tests actually use p_test_lock?
+    // XXX: to rerun, each ATOMIC_TEST initialize_lock() needs to detect reinitialization,
+    // e.g. to free up malloced memory
+
+    initialize_lock (p_locks->p_test_lock, p_pinorder->cpu_list, p_pinorder->num_threads);
+}
+
+
+
+// call the test-specific argument parsing routine; to be called from main()
+void measure_setup_parse_test_args (test_args_t * p_test_args, int argc, char ** argv) {
+    parse_test_args(p_test_args, argc, argv);
+}
+
+
+/* Simple linear barrier routine for synchronizing threads */
+static void synchronize_threads(uint64_t *barrier, unsigned long num_threads)
+{
+    // This works by using the barrier's bits 31..1 as a counter of the number
+    // of waiting threads.  When each thread enters this function, it
+    // increments the counter using fetchadd64_acquire(barrier, 2).
+
+    //   - All threads except the last one call wait32() on the upper 32-bits
+    //     of the barrier.
+    //   - When the last thread to enter increments the counter, it will
+    //     see that the updated counter matches num_threads - 1, and then it writes
+    //     a value that clears the counter and sets bit 60, the sense bit,
+    //     which is in the upper 32-bit half of the 64-bit barrier value.
+    //   - All the other threads' wait32() will see that write change the upper
+    //     32-bits, and will then exit this function.
+
+    // Note that the sense bit will be set after the barrier is passed, so a
+    // subsequent barrier call on the same variable will block on the sense bit
+    // being set until it is cleared.
+
+    // Also, if more than 2^31 threads are synchronizing, the counter increment
+    // will overflow into the upper 32-bits, resulting in the wait32() never
+    // seeing a value with just the sense bit set or cleared because the parts
+    // of the 32-bit value polled will have the upper bits of the non-zero
+    // counter value.  No check for this failure condition is provided as it
+    // is expected to be very difficult to synchronize over 2^31 threads.
+
+    const uint64_t SENSE_BIT_MASK = (1ULL << 60);
+
+    uint64_t global_sense = *barrier & SENSE_BIT_MASK;
+    uint64_t tmp_sense = ~global_sense & SENSE_BIT_MASK;
+    uint32_t local_sense = (uint32_t)(tmp_sense >> 32);
+
+    uint64_t old_barrier = fetchadd64_acquire(barrier, 2);
+    if (old_barrier == (((num_threads - 1) * 2) | global_sense)) {
+        // Make sure the store gets observed by the system. Reset count
+        // to zero and flip the sense bit.
+        __atomic_store_n(barrier, tmp_sense, __ATOMIC_RELEASE);
+    } else {
+        // Wait only on the sense bit to change.  Avoids race condition
+        // where a waiting thread can miss the update to the 64-bit value
+        // by the thread that releases the barrier and sees an update from
+        // a new thread entering, thus deadlocking us.
+        // NOTE: assumes little-endian organization so that the upper 32-bits
+        // of the 64-bit barrier is at barrier + 4.
+        wait32((uint32_t*)((uint8_t*)barrier + 4), local_sense);
+    }
+}
+
+
+void NOINLINE blackhole(unsigned long iters) {
+    if (! iters) { return; }
+#ifdef __aarch64__
+#if __clang__==1
+    asm volatile (".p2align 4; 1: add %0, %0, -1; cbnz  %0, 1b" : "=&r" (iters) : "0" (iters));
+#else
+    asm volatile (".p2align 4; 1: add %0, %0, -1; cbnz  %0, 1b" : "+r" (iters) : "0" (iters));
+#endif
+#elif __x86_64__
+    asm volatile (".p2align 4; 1: add $-1, %0; jne 1b" : "+r" (iters) );
+#endif
+}
+
+int64_t NOINLINE evaluate_loop_overhead(const unsigned long NUMTRIES)
+{
+    uint64_t LOOP_TEST_OVERHEAD = 0;
+    int64_t outer_cycles_start, outer_cycles_end;
+    unsigned long i, j;
+    int64_t outer_elapsed_total = 0;
+
+NO_UNROLL_LOOP
+    for (j = 0; j < 1000; j++) {
+        int64_t elapsed_total = 0;
+        outer_cycles_start = timer_get_counter_start();
+
+        for (i = 0; i < NUMTRIES; i++) {
+            uint64_t cycles_start, cycles_end;
+            cycles_start = timer_get_counter_start();
+            cycles_end = timer_get_counter_end();
+
+            int64_t elapsed  = MAX((int64_t)(cycles_end - cycles_start), 0);
+            elapsed_total += elapsed;
+        }
+
+        outer_cycles_end = timer_get_counter_end();
+        outer_elapsed_total = outer_cycles_end - outer_cycles_start;
+        LOOP_TEST_OVERHEAD += (outer_elapsed_total - elapsed_total);
+    }
+
+    LOOP_TEST_OVERHEAD = LOOP_TEST_OVERHEAD/j;
+    return LOOP_TEST_OVERHEAD;
+}
+
+
+int64_t evaluate_timer_overhead(void)
+{
+    uint64_t TIMER_OVERHEAD = 0;
+    int64_t outer_cycles_start, outer_cycles_end;
+    outer_cycles_start = timer_get_counter_start();
+    outer_cycles_end = timer_get_counter_end();
+    // Force measurement to 0 if it somehow goes negative
+    int64_t elapsed  = MAX(outer_cycles_end - outer_cycles_start, 0);
+    TIMER_OVERHEAD = elapsed;
+    return TIMER_OVERHEAD;
+}
+
+
+int64_t NOINLINE evaluate_blackhole(
+        const unsigned long tokens_mid, const unsigned long NUMTRIES)
+{
+    unsigned long i, j;
+    int64_t sum_elapsed_total = 0;
+    int64_t avg_elapsed_total = 0;
+#ifdef DDEBUG
+    int64_t outer_cycles_start, outer_cycles_end;
+    int64_t outer_elapsed_total;
+    int64_t outer_inner_diff;
+    int64_t elapsed_total_diff;
+    double percent;
+    int64_t LOOP_TEST_OVERHEAD = evaluate_loop_overhead(NUMTRIES);
+#endif
+    int64_t TIMER_OVERHEAD = evaluate_timer_overhead();
+
+NO_UNROLL_LOOP
+    for (j = 0; j < NUMTRIES; j++) {
+
+        int64_t elapsed_total = 0;
+
+#ifdef DDEBUG
+        outer_cycles_start = timer_get_counter_start();
+#endif
+NO_UNROLL_LOOP
+        for (i = 0; i < NUMTRIES; i++) {
+
+            uint64_t cycles_start, cycles_end;
+            cycles_start = timer_get_counter_start();
+            blackhole(tokens_mid);
+            cycles_end = timer_get_counter_end();
+
+            uint64_t elapsed  = cycles_end - cycles_start;
+                    // printf("elapsed = %lu\n", elapsed);
+
+            elapsed_total += elapsed;
+        }
+#ifdef DDEBUG
+        outer_cycles_end = timer_get_counter_end();
+#endif
+
+#ifdef DDEBUG
+        outer_elapsed_total = outer_cycles_end - outer_cycles_start;
+        outer_inner_diff = abs(outer_elapsed_total - elapsed_total);
+#endif
+
+        // Force measurements to zero if overhead swamps loop run time, in this
+        // case we can't measure this low of a requested time accurately.
+        sum_elapsed_total += MAX((int64_t)(elapsed_total - TIMER_OVERHEAD*NUMTRIES), 0);
+        avg_elapsed_total = sum_elapsed_total / (j + 1);
+
+#ifdef DDEBUG
+        elapsed_total_diff = abs(avg_elapsed_total - elapsed_total);
+        if (outer_inner_diff > LOOP_TEST_OVERHEAD) {
+            percent = outer_inner_diff / (double) LOOP_TEST_OVERHEAD;
+        } else {
+            percent = LOOP_TEST_OVERHEAD/ (double) outer_inner_diff;
+        }
+
+        printf("outer_elapsed_total = %lu "
+               "elapsed_total = %lu "
+               "outer_inner_diff = %lu percent_oh = %f percent_loop = %f\n",
+               outer_elapsed_total, elapsed_total, outer_inner_diff, percent,
+               (double) elapsed_total_diff / avg_elapsed_total);
+#endif
+    }
+
+    // returns average duration of NUMTRIES calls to blackhole with tokens_mid
+    long result = avg_elapsed_total;
+    return result;
+}
+
+unsigned long calibrate_blackhole(unsigned long target, unsigned long tokens_low,
+     unsigned long tokens_high, unsigned long core_id, unsigned long NUMTRIES)
+{
+    unsigned long tokens_diff = tokens_high - tokens_low;
+    unsigned long tokens_mid = (tokens_diff / 2) + tokens_low;
+    unsigned long target_elapsed_total = NUMTRIES * target;
+
+#ifdef DDEBUG
+    printf("target = %lu, target_elapsed_total = %lu, tokens_low = %lu, tokens_high = %lu, "
+           "tokens_diff = %lu, tokens_mid = %lu\n",
+            target, target_elapsed_total, tokens_low, tokens_high, tokens_diff, tokens_mid);
+#endif
+
+    if (tokens_diff == 1) {
+        // the answer is either tokens_low or tokens_high
+
+        unsigned long ret_low = evaluate_blackhole(tokens_low, NUMTRIES);
+        unsigned long ret_high = evaluate_blackhole(tokens_high, NUMTRIES);
+
+#ifdef DEBUG
+    printf("t(%lu) = %lu, tokens_mid = %lu target_elapsed_total = %lu\n",
+            core_id, ret_low, tokens_low, target_elapsed_total);
+    printf("t(%lu) = %lu, tokens_mid = %lu target_elapsed_total = %lu\n",
+            core_id, ret_high, tokens_high, target_elapsed_total);
+#endif
+        unsigned long low_diff = labs((long) (ret_low - target_elapsed_total));
+        unsigned long high_diff = labs((long) (ret_high - target_elapsed_total));
+
+        if (low_diff < high_diff) {
+            if (tokens_low >= (TOKENS_MAX_HIGH-1)) {
+                printf("tokens is TOKENS_MAX_HIGH or TOKENS_MAX_HIGH -1.  requested delay is too long or too short.\n");
+            }
+
+            return tokens_low;
+        }
+
+        if (tokens_high >= (TOKENS_MAX_HIGH-1)) {
+            printf("tokens is TOKENS_MAX_HIGH or TOKENS_MAX_HIGH -1.  requested delay is too long or too short.\n");
+        }
+
+        return tokens_high;
+    }
+
+    // Measure if this # of tokens is the proper #.
+    unsigned long t = evaluate_blackhole(tokens_mid, NUMTRIES);
+
+#ifdef DEBUG
+    printf("t(%lu) = %lu, tokens_mid = %lu target_elapsed_total = %lu\n", core_id, t, tokens_mid, target_elapsed_total);
+#endif
+
+    if (t > target_elapsed_total) {
+        tokens_mid = calibrate_blackhole(target, tokens_low, tokens_mid, core_id, NUMTRIES);
+    } else if (t < target_elapsed_total) {
+        tokens_mid = calibrate_blackhole(target, tokens_mid, tokens_high, core_id, NUMTRIES);
+    }
+
+    return tokens_mid;
+}
+
+static double measure_blackhole_duration(unsigned long count, unsigned long hwtimer_frequency) {
+
+    uint64_t hwtimer_start = timer_get_counter_start();
+    size_t n = 1000;
+    for (size_t i = 0; i < n; i++) {
+        blackhole(count);
+    }
+    uint64_t hwtimer_stop = timer_get_counter_start();
+
+    uint64_t hwtimer_diff = hwtimer_stop - hwtimer_start;
+    double ns_n = 1e9 * hwtimer_diff / hwtimer_frequency;
+    double ns = ns_n / n;
+
+    return ns;
+}
+
+/* Calculate timer spin-times where we do not access the clock.
+ * First calibrate the wait loop by doing a binary search around
+ * an estimated number of ticks. All threads participate to take
+ * into account pipeline effects of multithreading or hybrid cores.
+ */
+static void calibrate_timer(thread_args_t *x, unsigned long thread, unsigned long NUMTRIES)
+{
+    synchronize_threads(locks.p_calibrate_lock, x->num_threads);
+    if (x->hold_unit == NS) {
+        /* Determine how many timer ticks would happen for this wait time */
+        unsigned long hold = (unsigned long)((double)x->hold * x->tickspns);
+        /* Calibrate the number of loops we have to do */
+        x->hold_count = calibrate_blackhole(hold, 0, TOKENS_MAX_HIGH, thread, NUMTRIES);
+    } else {
+        x->hold_count = x->hold / 2;  // because there are 2 instructions in blackhole()
+    }
+
+    synchronize_threads(locks.p_calibrate_lock, x->num_threads);
+
+    if (x->post_unit == NS) {
+        unsigned long post = (unsigned long)((double)x->post * x->tickspns);
+        x->post_count = calibrate_blackhole(post, 0, TOKENS_MAX_HIGH, thread, NUMTRIES);
+    } else {
+        x->post_count = x->post / 2;  // because there are 2 instructions in blackhole()
+    }
+
+    synchronize_threads(locks.p_calibrate_lock, x->num_threads);
+
+    double hold_ns = measure_blackhole_duration(x->hold_count, x->hwtimer_frequency);
+
+    synchronize_threads(locks.p_calibrate_lock, x->num_threads);
+
+    double post_ns = measure_blackhole_duration(x->post_count, x->hwtimer_frequency);
+
+    synchronize_threads(locks.p_calibrate_lock, x->num_threads);
+
+    x->results.hold_ns = hold_ns;
+    x->results.post_ns = post_ns;
+
+    if (x->verbose >= VERBOSE_YES)
+    printf("Calibrated thread %lu on CPU %lu with hold = %lu %s (hold_count = %lu) -> %0.2f ns; post = %lu %s (post_count = %lu) -> %0.2f ns\n",
+            thread, x->run_on_this_cpu,
+            x->hold, x->hold_unit == NS? "ns" : "instructions", x->hold_count, hold_ns,
+            x->post, x->post_unit == NS? "ns" : "instructions", x->post_count, post_ns);
+
+    synchronize_threads(locks.p_calibrate_lock, x->num_threads);
+}
+
+
+#if defined(__LINUX_OSQ_LOCK_H) && defined(OSQ_LOCK_COUNT_LOOPS)
+
+#undef lock_acquire
+#define lock_acquire(lock, thread) osq_lock_acquire(lock, thread, &osq_lock_wait_next_spins, &osq_lock_locked_spins, &osq_lock_unqueue_spins, &osq_lock_acquire_backoffs)
+
+#undef lock_release
+#define lock_release(lock, thread) osq_lock_release(lock, thread, &osq_unlock_wait_next_spins)
+
+#elif defined(__LINUX_OSQ_LOCK_H) && !defined(OSQ_LOCK_COUNT_LOOPS)
+
+#undef lock_acquire
+#define lock_acquire(lock, thread) osq_lock_acquire(lock, thread)
+
+#undef lock_release
+#define lock_release(lock, thread) osq_lock_release(lock, thread)
+
+#endif
+
+
+
+#ifdef PROGRESS_TICK_PROFILE
+static void update_timer_tick_progress(unsigned long lock_acquires,
+        unsigned long target_10p, unsigned long * __restrict__ hwtimer_10p,
+        unsigned long target_25p, unsigned long * __restrict__ hwtimer_25p,
+        unsigned long target_50p, unsigned long * __restrict__ hwtimer_50p,
+        unsigned long target_75p, unsigned long * __restrict__ hwtimer_75p,
+        unsigned long target_90p, unsigned long * __restrict__ hwtimer_90p) {
+
+    if (lock_acquires > target_10p && *hwtimer_10p == 0) {
+        *hwtimer_10p = get_raw_counter();
+        return;
+    }
+
+    if (lock_acquires > target_25p && *hwtimer_25p == 0) {
+        *hwtimer_25p = get_raw_counter();
+        return;
+    }
+
+    if (lock_acquires > target_50p && *hwtimer_50p == 0) {
+        *hwtimer_50p = get_raw_counter();
+        return;
+    }
+
+    if (lock_acquires > target_75p && *hwtimer_75p == 0) {
+        *hwtimer_75p = get_raw_counter();
+        return;
+    }
+
+    if (lock_acquires > target_90p && *hwtimer_90p == 0) {
+        *hwtimer_90p = get_raw_counter();
+        return;
+    }
+}
+#endif
+
+typedef struct {
+    thread_args_t * x;
+    volatile unsigned long lock_acquires;
+    volatile unsigned long total_depth;
+    unsigned long thread;
+    struct timespec * ptv_monot_start;
+    struct timespec * ptv_start;
+    unsigned long ticks_start;
+    unsigned long ticks_end;
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    unsigned long * posq_lock_wait_next_spins;
+    unsigned long * posq_unlock_wait_next_spins;
+    unsigned long * posq_lock_locked_spins;
+    unsigned long * posq_lock_unqueue_spins;
+    unsigned long * posq_lock_acquire_backoffs;
+#endif
+
+} cleanup_struct_t;
+
+static void thread_cleanup_routine(cleanup_struct_t * pcs) {
+    printf("thread_cleanup_routine called\n");
+
+    thread_args_t *x = pcs->x;
+    struct timespec tv_monot_end, tv_end;
+
+    unsigned long ticks_end = get_raw_counter();
+
+    clock_gettime(CLOCK_MONOTONIC, &tv_monot_end);      // wall-clock time since epoch, but XXX should use CLOCK_MONOTONIC_RAW???
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_end);    // CPU time spent by this thread
+
+    if (pcs->thread == 0)
+        *(x->p_start_ns) = timespec_to_ns(pcs->ptv_monot_start);
+
+    unsigned long cputime_ns = timespec_to_ns(&tv_end) - timespec_to_ns(pcs->ptv_start);
+    unsigned long walltime_ns = timespec_to_ns(&tv_monot_end) - timespec_to_ns(pcs->ptv_monot_start);
+
+    per_thread_results_t * p = &x->results;
+
+    p->lock_acquires = pcs->lock_acquires;
+
+    p->cputime_ns = cputime_ns;
+    p->walltime_ns = walltime_ns;
+
+    p->hmrdepth = pcs->total_depth;
+
+    p->hwtimer_start = pcs->ticks_start;
+    p->hwtimer_end = ticks_end;
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    p->osq_lock_wait_next_spins   = *(pcs->posq_lock_wait_next_spins);
+    p->osq_unlock_wait_next_spins = *(pcs->posq_unlock_wait_next_spins);
+    p->osq_lock_locked_spins      = *(pcs->posq_lock_locked_spins);
+    p->osq_lock_unqueue_spins     = *(pcs->posq_lock_unqueue_spins);
+    p->osq_lock_acquire_backoffs  = *(pcs->posq_lock_acquire_backoffs);
+#endif
+}
+
+
+// hmr is called by pthread_create()
+
+void* hmr(void *ptr)
+{
+    unsigned long lock_acquires = 0;
+    thread_args_t *x = (thread_args_t *) ptr;
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    unsigned long osq_lock_wait_next_spins = 0;
+    unsigned long osq_unlock_wait_next_spins = 0;
+    unsigned long osq_lock_locked_spins = 0;
+    unsigned long osq_lock_unqueue_spins = 0;
+    unsigned long osq_lock_acquire_backoffs = 0;
+#endif
+
+    unsigned long *lock = x->lock;          // address of the lock variable
+    unsigned long num_acquires = x->num_acquires;   // number of acquires (per thread)
+
+    unsigned long run_on_this_cpu = x->run_on_this_cpu;
+    unsigned long num_threads = x->num_threads;
+
+    unsigned long hold_count = x->hold;
+    unsigned long post_count = x->post;
+
+    unsigned long thread = x->thread_num;   // thread is hmr thread number, starting with 0.  Not a core or CPU.  Super confusing.
+
+    struct timespec tv_monot_start, tv_monot_end, tv_cputime_start, tv_cputime_end;
+    unsigned long total_depth = 0;
+    unsigned long run_limit_ticks = x->run_limit_ticks;
+    unsigned long run_limit_inner_loop_iters = x->run_limit_inner_loop_iters;
+    unsigned long ticks_start;
+    unsigned long ticks_end;
+
+    per_thread_results_t * presults = &x->results;
+
+    cpu_set_t affin_mask;
+
+    CPU_ZERO(&affin_mask);
+
+    // all threads increment the counter part of p_sync_lock
+    fetchadd64_acquire(locks.p_sync_lock, 2);
+
+    cleanup_struct_t cs = {
+        .x = x,
+        .lock_acquires = 0,
+        .ptv_monot_start = &tv_monot_start,
+        .ptv_start = &tv_cputime_start,
+        .thread = thread,
+#ifdef OSQ_LOCK_COUNT_LOOPS
+        .posq_lock_wait_next_spins   = &osq_lock_wait_next_spins,
+        .posq_unlock_wait_next_spins = &osq_unlock_wait_next_spins,
+        .posq_lock_locked_spins      = &osq_lock_locked_spins,
+        .posq_lock_unqueue_spins     = &osq_lock_unqueue_spins,
+        .posq_lock_acquire_backoffs  = &osq_lock_acquire_backoffs,
+#endif
+    };
+
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    pthread_cleanup_push((void (*)(void *)) thread_cleanup_routine, &cs);
+
+    thread_local_init(thread);  // if defined, call the lock algorithm test-specific init function by thread
+
+    // set up CPU affinity --------------------------------------------
+
+    CPU_SET(run_on_this_cpu, &affin_mask);
+    presults->cpu_affined = run_on_this_cpu;
+
+    int ret = sched_setaffinity(0, sizeof(cpu_set_t), &affin_mask);
+    if (ret == -1) {
+        fprintf(stderr, "ERROR: sched_setaffinity() returned -1 when trying to run on CPU%lu; it is probably not online.\n", run_on_this_cpu);
+        exit(-1);
+    }
+
+    // synchronize to calculate blackhole -----------------------------
+
+    if (thread == 0) {
+        wait64(locks.p_ready_lock, num_threads - 1); // wait until p_ready_lock has the value num_threads-1 by subordinate threads' incrementing
+
+        // marshal thread sets lsb of p_sync_lock
+        unsigned long p_sync_lock_value = fetchadd64_release(locks.p_sync_lock, 1);   // p_sync_lock should be ((num_threads * 2) | 1) after this
+#ifdef DDEBUG
+        if (p_sync_lock_value != (num_threads << 1)) {
+            fprintf(stderr, "unexpectedly, p_sync_lock did not have the expected value.\n");
+            exit(-1);
+        }
+#else
+        (void) p_sync_lock_value;
+#endif
+    } else {
+        fetchadd64_release(locks.p_ready_lock, 1);  // all subordinate threads add 1 to p_ready_lock
+
+        /* Spin until the "marshal" sets the lsb of p_sync_lock */
+        wait64(locks.p_sync_lock, (num_threads * 2) | 1);
+    }
+
+    // All threads calibrate their own blackhole timer -----
+
+    calibrate_timer(x, thread, x->blackhole_numtries);
+    hold_count = x->hold_count;
+    post_count = x->post_count;
+
+#ifdef __LINUX_OSQ_LOCK_H
+    synchronize_threads(locks.p_calibrate_lock, num_threads);
+    osq_lock_compute_blackhole_interval(thread, x->tickspns, run_on_this_cpu, x->blackhole_numtries);
+#endif
+
+    if (thread == 0 && x->verbose >= VERBOSE_YES) {
+        printf("Measurement is about to start...\n");
+    }
+
+    // Wait for all threads to arrive from calibration ----------------
+    synchronize_threads(locks.p_calibrate_lock, num_threads);
+
+#ifdef DDEBUG
+    printf("thread %lu: hold_count=%ld post_count=%ld\n", thread, hold_count, post_count);
+#endif
+
+    // Finally do the measurement ------------------------------------
+
+    if (run_limit_ticks) {
+
+        // run for an amount of time
+
+        // TODO: for run_limit_ticks, count lock_acquires completed at tick milestones instead of ticks at lock_acquires milestones
+
+        clock_gettime(CLOCK_MONOTONIC, &tv_monot_start);
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_cputime_start);
+
+        cs.ticks_start = ticks_start = get_raw_counter();
+
+        do {
+
+            for (size_t i = 0; i < run_limit_inner_loop_iters; i++) {
+                /* Do a lock thing */
+#ifndef __LINUX_OSQ_LOCK_H
+                // osq_lock does not use the lock pointer because each node has
+                // its own osq in a separate cacheline, so this prefetch is redundant
+                prefetch64(lock);
+#endif
+                total_depth += lock_acquire(lock, thread);
+                blackhole(hold_count);
+                lock_release(lock, thread);
+                blackhole(post_count);
+                lock_acquires++;
+            }
+
+            cs.ticks_end = ticks_end = get_raw_counter();
+            cs.total_depth = total_depth;
+            cs.lock_acquires = lock_acquires;
+            // XXX: the problem with this is that lock_acquire() / lock_release() could livelock
+            // before the for loop finishes, so cs.lock_acquires never gets updated.
+
+        } while (ticks_end - ticks_start < run_limit_ticks);
+
+        clock_gettime(CLOCK_MONOTONIC, &tv_monot_end);
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_cputime_end);
+
+    } else {
+
+        // run for a number of acquires
+
+#ifdef PROGRESS_TICK_PROFILE
+        unsigned long target_25p = num_acquires / 4;
+        unsigned long target_50p = target_25p * 2;
+        unsigned long target_75p = target_25p * 3;
+
+        unsigned long target_10p = num_acquires * 0.1;
+        unsigned long target_90p = num_acquires * 0.9;
+
+        unsigned long hwtimer_10p = 0;
+        unsigned long hwtimer_25p = 0;
+        unsigned long hwtimer_50p = 0;
+        unsigned long hwtimer_75p = 0;
+        unsigned long hwtimer_90p = 0;
+#endif
+
+        clock_gettime(CLOCK_MONOTONIC, &tv_monot_start);
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_cputime_start);
+
+        cs.ticks_start = ticks_start = get_raw_counter();
+
+        while (!num_acquires || lock_acquires < num_acquires) {
+            /* Do a lock thing */
+#ifndef __LINUX_OSQ_LOCK_H      // osq_lock does not use the lock pointer, and these prefetches of it are redundant
+            prefetch64(lock);
+#endif
+            total_depth += lock_acquire(lock, thread);
+            blackhole(hold_count);
+            lock_release(lock, thread);
+            blackhole(post_count);
+
+#ifdef PROGRESS_TICK_PROFILE
+            // records ticks at lock_acquires milestones
+            update_timer_tick_progress(lock_acquires,
+                    target_10p, &hwtimer_10p,
+                    target_25p, &hwtimer_25p,
+                    target_50p, &hwtimer_50p,
+                    target_75p, &hwtimer_75p,
+                    target_90p, &hwtimer_90p);
+#endif
+
+            lock_acquires++;
+            cs.lock_acquires = lock_acquires; // XXX: will doing this be too much?
+            cs.total_depth = total_depth;
+        }
+
+        cs.ticks_end = ticks_end = get_raw_counter();
+
+        clock_gettime(CLOCK_MONOTONIC, &tv_monot_end);
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tv_cputime_end);
+
+#ifdef PROGRESS_TICK_PROFILE
+        presults->hwtimer_10p = hwtimer_10p;
+        presults->hwtimer_25p = hwtimer_25p;
+        presults->hwtimer_50p = hwtimer_50p;
+        presults->hwtimer_75p = hwtimer_75p;
+        presults->hwtimer_90p = hwtimer_90p;
+#endif
+    }
+
+    // Measurement done; record results per thread -------------------
+
+    if (thread == 0)
+        *(x->p_start_ns) = timespec_to_ns(&tv_monot_start);
+
+    unsigned long cputime_ns = timespec_to_ns(&tv_cputime_end) - timespec_to_ns(&tv_cputime_start);
+    unsigned long walltime_ns = timespec_to_ns(&tv_monot_end) - timespec_to_ns(&tv_monot_start);
+
+    presults->lock_acquires = lock_acquires;
+    presults->cputime_ns = cputime_ns;
+    presults->walltime_ns = walltime_ns;
+    presults->hmrdepth = total_depth;        // writes to hmrdepth[]
+
+    presults->hwtimer_start = ticks_start;
+    presults->hwtimer_end = ticks_end;
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    presults->osq_lock_wait_next_spins   = osq_lock_wait_next_spins;
+    presults->osq_unlock_wait_next_spins = osq_unlock_wait_next_spins;
+    presults->osq_lock_locked_spins      = osq_lock_locked_spins;
+    presults->osq_lock_unqueue_spins     = osq_lock_unqueue_spins;
+    presults->osq_lock_acquire_backoffs  = osq_lock_acquire_backoffs;
+#endif
+
+    pthread_cleanup_pop(0);
+
+    return NULL;
+}
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/src/report.c
+++ b/benchmarks/lockhammer/src/report.c
@@ -1,0 +1,1067 @@
+
+/*
+ * Copyright (c) 2017-2025, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <locale.h>
+#ifdef JSON_OUTPUT
+#include <limits.h>
+#include <jansson.h>
+#endif
+
+#include "verbose.h"
+#include "lockhammer.h"
+#include "perf_timer.h"
+
+extern thread_args_t thread_args[];
+extern unsigned long hwtimer_diff[];
+
+extern const char * test_name;
+extern const char * variant_name;
+
+static char is_earlier_than_range(unsigned long v, thread_args_t * haystack, size_t num_threads) {
+    for (size_t i = 0; i < num_threads; i++) {
+        if (v < haystack[i].results.hwtimer_start) { return '<'; }
+    }
+    return ' ';
+}
+
+static char is_later_than_range(unsigned long v, thread_args_t * haystack, size_t num_threads) {
+    for (size_t i = 0; i < num_threads; i++) {
+        if (v > haystack[i].results.hwtimer_end) { return '<'; }
+    }
+    return ' ';
+}
+
+static char denote_end(unsigned long v, thread_args_t * haystack, size_t num_threads, unsigned long hwtimer_end_earliest, unsigned long hwtimer_end_latest) {
+    for (size_t i = 0; i < num_threads; i++) {
+        if (v == hwtimer_end_earliest) { return '^'; }
+        if (v == hwtimer_end_latest) { return '$'; }
+    }
+    return ' ';
+}
+
+typedef struct {
+    unsigned long thread_num;               // which worker thread is this
+    unsigned long cpu_num;                  // CPU on which this thread was assigned
+    unsigned long lock_acquires;            // number of lock acquires/releases this thread did
+    double        lock_acquires_sigmas;     // population standard deviations from the mean
+    double        lock_acquires_percent;    // percent of total_lock_acquires that this thread did
+    unsigned long cpu_time_ns;              // CPU time incurred by this thread
+    unsigned long walltime_ns;              // wall clock time incurred by this thread
+    double        depth;                    // total_depth / lock_acquires, should be "gross depth"?
+    double        critical_ns_per_loop;     // measured hold duration from calibration of this thread
+    double        parallel_ns_per_loop;     // measured post duration from calibration of this thread
+    unsigned long hwtimer_start;            // hwtimer start before measurement
+    unsigned long hwtimer_end;              // hwtimer start after measurement
+} per_thread_stats_t;
+
+typedef struct {
+    pinorder_t *  pinorder;
+    per_thread_stats_t * per_thread_stats;
+
+    unsigned long nominal_critical, nominal_parallel;
+    const char * nominal_critical_unit, * nominal_parallel_unit;
+
+    // workload/duration limit
+    unsigned long run_limit_num_acquires;
+    unsigned long run_limit_ticks;
+    double        run_limit_seconds;
+
+    // hwtimer frequency
+    unsigned long hwtimer_frequency;        // if non-zero, then it was passed in using the --hwtimer-frequency flag
+    unsigned long probed_hwtimer_frequency; // if non-zero, then it is from timer_get_timer_freq(), which could be wrong
+
+    const char * test_name;
+    const char * variant_name;
+
+    unsigned long meas_number;
+    unsigned long test_number;
+    unsigned long iteration;
+    unsigned long num_threads;
+    double        avg_critical_ns_per_loop;
+    double        avg_parallel_ns_per_loop;
+    double        full_concurrency_fraction;
+
+    // basic metrics
+    unsigned long total_lock_acquires;
+    double        lock_acquires_mean;
+    double        lock_acquires_stddev;
+    double        lock_acquires_stddev_over_mean;
+
+    // duration metrics
+    unsigned long wall_elapsed_ns;
+    unsigned long total_cputime_ns;
+    unsigned long total_parallel_cputime_ns;
+    unsigned long total_critical_cputime_ns;
+
+    // overhead metrics
+    unsigned long total_lock_overhead_cputime_ns;
+    double        avg_lock_overhead_cputime_ns;
+    double        lock_overhead_cputime_percent;
+
+    // performance metrics
+    double        cputime_ns_per_lock_acquire;
+    double        wall_elapsed_ns_per_lock_acquire;
+    double        total_lock_acquires_per_second;
+
+    // ratio metrics
+    double        cpu_to_wall_elapsed_ratio;
+    double        mean_lock_depth;
+
+#if 0
+    // TODO: tick profile summary coverage data, but maybe this should be in a separate structure?
+    unsigned long hwtimer_start_spread;
+    unsigned long hwtimer_stop_spread;
+    unsigned long hwtimer_duration_spread;
+    unsigned long hwtimer_long_short;
+    double        mean_hwtimer_diff;
+    double        stddev_hwtimer_diff;
+#endif
+} report_data_t;
+
+size_t num_reports = 0;
+size_t report_capacity = 0;
+report_data_t * report_summary;
+
+
+void standard_report (pinorder_t * p_pinorder, unsigned long meas_number, unsigned long test_number, unsigned long iteration, unsigned long wall_elapsed_ns, test_args_t * p_test_args, const duration_t * crit, const duration_t * par) {
+
+    // wall_elapsed_ns is wall clock time from when the marshal thread
+    // starts measuring to when the parent thread joins all workers.
+
+/*  old variable                 old output                     new code var name                          meaning
+    result                       "lock loops"                   lock_acquires                              number of iterations of the lock acquire/critical_blackhole/lock release/parallel_blackhole loop
+                                                                lock_acquires_mean                         average number of lock acquires per thread
+    sched_elapsed                "ns scheduled"                 total_cputime_ns                           total of all worker threads' CPU time
+    realcpu_elapsed              (not reported)                 total_walltime_ns                          total of all worker threads' per CPU wall-clock time (can this actually make sense to measure? maybe if the busy loops were actually idle/sleep, but that is not implemented (yet))
+    real_elapsed                 "ns elapsed"                   wall_elapsed_ns                            wall-clock time elapsed
+    sched_elapsed/real_elapsed   "~%f cores"                    cpu_to_wall_elapsed_ratio                  total CPU time divided by wall clock elapsed time
+    sched_elapsed/result         "ns per access (scheduled)"    cputime_ns_per_lock_acquire                average CPU time per acquired lock -- includes the parallel sections!!!
+    realcpu_elapsed/result       "ns per access (real)"         walltime_ns_per_lock_acquire               average CPU wall-clock time per acquired lock (does this actually make sense?)
+    real_elapsed/result          "ns access rate"               wall_elapsed_ns_per_lock_acquire           wall-clock time per acquired lock
+    avg_lock_depth               "average depth"                mean_lock_depth                            average lock depth (TBD)
+                                                                lock_overhead_cputime_ns                   total_cputime_ns - per_thread { lock_acquires * (critial_ns + parallel_ns) }
+*/
+
+    int verbose = p_test_args->verbose;
+    unsigned long num_threads = p_pinorder->num_threads;
+
+    if (num_reports == report_capacity) {
+        const size_t capacity_increase_size = 10;
+        report_summary = reallocarray(report_summary, num_reports + capacity_increase_size, sizeof(report_summary[0]));
+        if (! report_summary) { fprintf(stderr, "ERROR: failed report size reallocation\n"); exit(-1); }
+        report_capacity += capacity_increase_size;
+        // printf("increased report capacity to %zu\n", report_capacity);
+    }
+    report_data_t * s = &(report_summary[num_reports]);
+
+    double mean_lock_depth = 0.0;
+
+    unsigned long total_lock_acquires = 0;   // total lock acquires (and releases)
+    unsigned long total_cputime_ns = 0;      // total CPU time
+    unsigned long total_parallel_cputime_ns = 0;     // total CPU time in parallel section
+    unsigned long total_critical_cputime_ns = 0;     // total CPU time in critical section
+    unsigned long total_lock_overhead_cputime_ns = 0;
+
+    for (size_t i = 0; i < num_threads; i++) {
+
+        per_thread_results_t * p = &thread_args[i].results;
+
+        unsigned long lock_acquires = p->lock_acquires;
+        unsigned long cputime_ns = p->cputime_ns;
+
+        total_lock_acquires += lock_acquires;
+        total_cputime_ns += cputime_ns;
+
+        // estimate lock overhead by subtracting the parallel and critical cputime from the thread cputime
+
+        double critical_ns = p->hold_ns * lock_acquires;
+        double parallel_ns = p->post_ns * lock_acquires;
+
+        total_critical_cputime_ns += critical_ns;
+        total_parallel_cputime_ns += parallel_ns;
+
+        const char * capped = "";
+        double lock_overhead_cputime_ns = cputime_ns - critical_ns - parallel_ns;
+        if (lock_overhead_cputime_ns < 0) {
+            // cputime_ns is measured but critical_ns and parallel_ns are estimated
+            // by measuring a few iterations and scaling by lock_acquires, so the
+            // result of the lock_overhead_cputime_ns can be negative if the
+            // overhead is actually very small (such as in lh_empty).
+            lock_overhead_cputime_ns = 0;
+            capped = "*";
+        }
+        if (0)
+        printf("thread %zu lock_overhead_cputime_ns = %f%s, cputime_ns = %lu, critical_ns = %f, parallel_ns = %f\n",
+                i, lock_overhead_cputime_ns, capped, cputime_ns, critical_ns, parallel_ns);
+
+        total_lock_overhead_cputime_ns += lock_overhead_cputime_ns;
+
+        /* Average lock "depth" is an algorithm-specific auxiliary metric
+           whereby each algorithm can report an approximation of the level
+           of contention it observes.  This estimate is returned from each
+           call to lock_acquire and accumulated per thread.  These results
+           are then aggregated and averaged here so that an overall view
+           of the run's contention level can be determined. */
+
+        mean_lock_depth += (double) p->hmrdepth / p->lock_acquires;
+
+    }
+
+    mean_lock_depth /= num_threads;
+
+    double avg_lock_overhead_cputime_ns = (double) total_lock_overhead_cputime_ns / total_lock_acquires;
+
+    double lock_overhead_cputime_percent = (double) total_lock_overhead_cputime_ns / total_cputime_ns * 100;
+
+    double cputime_ns_per_lock_acquire = (double) total_cputime_ns / total_lock_acquires;
+    double cpu_to_wall_elapsed_ratio = (double) total_cputime_ns / wall_elapsed_ns;
+
+
+    // compute the full concurrency fraction.
+
+    // Example of using 3 threads that start/end at slightly different times
+    // where x-axis is time and 'o' means the thread is running.
+
+    //  T0 ...ooooo...
+    //  T1 ...oooo....
+    //  T2 ....oooo...
+    //         ^^^__only these 3 cycles have the full 3-thread concurrency
+    //        ^^^^^__threads ran for 5 cycles
+    //        full_concurrency_fraction = 3 / 5 = 0.6
+
+
+    // Longer example showing more full-thread concurrency by running longer.
+
+    //  T0 ...ooooooooooooooooooooo...
+    //  T1 ...oooooooooooooooooooooo..
+    //  T2 ....ooooooooooooooooooooo..
+    //         ^^^^^^^^^^^^^^^^^^^^__3 threads ran concurrently for 20 cycles
+    //        ^^^^^^^^^^^^^^^^^^^^^^^___over a span of 23 cycles
+    //        full_concurrency_fraction = 20 / 21 = 0.952
+
+
+    // Example where thread T0 ended before the other started.
+
+    //  T0 ...ooooo.........
+    //  T1 .........oooo....
+    //  T2 ..........oooo...
+    //          0 cycles had all 3 threads running at the same time
+    //        ^^^^^^^^^^^ span of 11 cycles
+    //        full_concurrency_fraction = 0 / 11 = 0
+
+    unsigned long earliest_hwtimer_start = -1;
+    unsigned long earliest_hwtimer_end = -1;
+    unsigned long latest_hwtimer_start = 0;
+    unsigned long latest_hwtimer_end = 0;
+
+    for (size_t i = 0; i < num_threads; ++i) {
+        per_thread_results_t * p = &thread_args[i].results;
+
+        earliest_hwtimer_start = (p->hwtimer_start < earliest_hwtimer_start) ? p->hwtimer_start : earliest_hwtimer_start;
+        earliest_hwtimer_end   = (p->hwtimer_end   < earliest_hwtimer_end  ) ? p->hwtimer_end   : earliest_hwtimer_end  ;
+
+        latest_hwtimer_start   = (p->hwtimer_start > latest_hwtimer_start)   ? p->hwtimer_start : latest_hwtimer_start;
+        latest_hwtimer_end     = (p->hwtimer_end   > latest_hwtimer_end  )   ? p->hwtimer_end   : latest_hwtimer_end  ;
+    }
+
+    double full_concurrency_fraction = ((double) (earliest_hwtimer_end - latest_hwtimer_start)) / (latest_hwtimer_end - earliest_hwtimer_start);
+    if (full_concurrency_fraction < 0) {
+        // if a thread finished before another one started, there is no possibility of full concurrency.
+        full_concurrency_fraction = 0.;
+    }
+
+    if (verbose >= VERBOSE_MORE) {
+        printf("earliest_hwtimer_start    = %lu\n", earliest_hwtimer_start);
+        printf("earliest_hwtimer_end      = %lu\n", earliest_hwtimer_end  );
+        printf("latest_hwtimer_start      = %lu\n", latest_hwtimer_start);
+        printf("latest_hwtimer_end        = %lu\n", latest_hwtimer_end  );
+        printf("full_concurrency_fraction = %f\n", full_concurrency_fraction);
+    }
+
+    // report per thread lock acqusition fairness
+
+    double lock_acquires_mean = (double) total_lock_acquires / num_threads;
+    double lock_acquires_sum_diff_squared = 0;
+
+    for (size_t i = 0; i < num_threads; ++i) {
+        per_thread_results_t * p = &thread_args[i].results;
+        double diff_mean = (p->lock_acquires - lock_acquires_mean);
+        lock_acquires_sum_diff_squared += diff_mean * diff_mean;
+    }
+
+    lock_acquires_sum_diff_squared /= num_threads;  // variance
+
+    double lock_acquires_stddev = sqrt(lock_acquires_sum_diff_squared);
+
+    per_thread_stats_t * per_thread_stats = malloc(sizeof(per_thread_stats_t) * num_threads);   // XXX: never free'd
+
+    if (per_thread_stats == NULL) { fprintf(stderr, "ERROR mallocing per_thread_stats\n"); exit(-1); }
+
+    // compute average critical and parallel durations and per-thread stats
+
+    double avg_critical_ns_per_loop = 0;
+    double avg_parallel_ns_per_loop = 0;
+
+    for (size_t i = 0; i < num_threads; ++i) {
+        per_thread_results_t * p = &thread_args[i].results;
+        double lock_acquires_percent = p->lock_acquires * 100. / total_lock_acquires;
+        double critical_ns_per_loop = p->hold_ns;
+        double parallel_ns_per_loop = p->post_ns;
+
+        per_thread_stats[i] = (per_thread_stats_t) {
+            .thread_num            = i,
+            .cpu_num               = p->cpu_affined,
+            .lock_acquires         = p->lock_acquires,
+            .lock_acquires_sigmas  = (p->lock_acquires - lock_acquires_mean) / lock_acquires_stddev,
+            .lock_acquires_percent = lock_acquires_percent,
+            .cpu_time_ns           = p->cputime_ns,
+            .walltime_ns           = p->walltime_ns,
+            .depth                 = (double) p->hmrdepth / p->lock_acquires,
+            .critical_ns_per_loop  = critical_ns_per_loop,
+            .parallel_ns_per_loop  = parallel_ns_per_loop,
+            .hwtimer_start         = p->hwtimer_start,
+            .hwtimer_end           = p->hwtimer_end,
+        };
+
+        avg_critical_ns_per_loop += critical_ns_per_loop;
+        avg_parallel_ns_per_loop += parallel_ns_per_loop;
+    }
+
+    avg_critical_ns_per_loop /= num_threads;
+    avg_parallel_ns_per_loop /= num_threads;
+
+    s->per_thread_stats = per_thread_stats;
+
+    if (verbose >= VERBOSE_MORE)
+        for (size_t i = 0; i < num_threads; ++i) {
+            per_thread_stats_t * p = &per_thread_stats[i];
+            printf("thread %zu (cpu %lu): lock_acquires = %lu (%.3f sigmas), lock_acquires_percent = %0.2f%%, cputime_ns = %lu, walltime_ns = %lu, depth = %0.3f, critical_ns = %.f (per loop), parallel_ns = %.f (per loop)\n",
+                p->thread_num,
+                p->cpu_num,
+                p->lock_acquires,
+                p->lock_acquires_sigmas,
+                p->lock_acquires_percent,
+                p->cpu_time_ns,
+                p->walltime_ns,
+                p->depth,
+                p->critical_ns_per_loop,
+                p->parallel_ns_per_loop);
+        }
+
+    double wall_elapsed_ns_per_lock_acquire = (double) wall_elapsed_ns / total_lock_acquires;
+    double total_lock_acquires_per_second = total_lock_acquires * 1e9 / wall_elapsed_ns;
+
+    // TODO: rename wall time to something else as not to be confused with wall_elapsed time (which is what we normally associated with wall clock time)
+
+    s->pinorder = p_pinorder;
+    s->iteration = iteration;
+    s->meas_number = meas_number;
+    s->test_number = test_number;
+    s->num_threads = num_threads;
+    s->total_lock_acquires = total_lock_acquires;
+    s->lock_acquires_mean = lock_acquires_mean;
+    s->lock_acquires_stddev = lock_acquires_stddev;
+    s->lock_acquires_stddev_over_mean = lock_acquires_stddev/lock_acquires_mean;
+    s->avg_critical_ns_per_loop = avg_critical_ns_per_loop;
+    s->avg_parallel_ns_per_loop = avg_parallel_ns_per_loop;
+
+    s->full_concurrency_fraction = full_concurrency_fraction;
+
+    s->test_name = test_name;
+    s->variant_name = variant_name;
+
+    s->nominal_critical = crit->t;
+    s->nominal_parallel = par->t;
+    s->nominal_critical_unit = (crit->unit == NS) ? "ns" : "inst";
+    s->nominal_parallel_unit = (par->unit == NS) ? "ns" : "inst";
+
+    //printf("nominal_critical = %lu%s, nominal_parallel = %lu%s\n", s->nominal_critical, s->nominal_critical_unit, s->nominal_parallel, s->nominal_parallel_unit);
+
+    s->run_limit_num_acquires = p_test_args->num_acquires;
+    s->run_limit_ticks = p_test_args->run_limit_ticks;
+    s->run_limit_seconds = p_test_args->run_limit_seconds;
+
+    s->hwtimer_frequency = p_test_args->hwtimer_frequency;
+    s->probed_hwtimer_frequency = p_test_args->probed_hwtimer_frequency;
+
+    if (verbose >= VERBOSE_YES) {
+    printf("basic metrics:___________________________________________\n");
+
+    // number of worker threads
+    printf("num_threads = %lu [thrds]\n", num_threads);
+
+    // total number of lock acquire + release loop iterations across all threads
+    printf("total_lock_acquires = %lu\n", total_lock_acquires);
+
+    // average number of lock acquires per thread
+    printf("lock_acquires_mean = %.3f per thread, stddev = %.3f, stddev/mean = %f\n", lock_acquires_mean, lock_acquires_stddev, lock_acquires_stddev/lock_acquires_mean);
+
+    // average critical and parallel durations per loop, as measured in per-thread calibration
+    printf("avg_critical_ns_per_loop = %.3f [crit_ns]\n", avg_critical_ns_per_loop);
+    printf("avg_parallel_ns_per_loop = %.3f [par_ns]\n", avg_parallel_ns_per_loop);
+
+    // fraction of the measurement time that all threads were concurrent
+    printf("full_concurrency_fraction = %0.3f\n", full_concurrency_fraction);
+    printf("lock_acquires_stddev_over_mean = %0.3f\n", s->lock_acquires_stddev_over_mean);
+    }
+
+
+    // durations
+
+    s->wall_elapsed_ns = wall_elapsed_ns;
+    s->total_cputime_ns = total_cputime_ns;
+    s->total_parallel_cputime_ns = total_parallel_cputime_ns;
+    s->total_critical_cputime_ns = total_critical_cputime_ns;
+
+    if (verbose >= VERBOSE_YES) {
+    printf("duration metrics:________________________________________\n");
+
+    // wall clock elapsed time in nanoseconds -- this is the 'singular' wall clock time
+    printf("wall_elapsed_ns = %lu (%.2f seconds)\n", wall_elapsed_ns, wall_elapsed_ns / 1e9);
+
+    // total CPU time used by all threads in nanoseconds
+    printf("total_cputime_ns = %lu (%0.2f seconds)\n", total_cputime_ns, total_cputime_ns / 1e9);
+
+    // total CPU time spent in parallel (post) in nanoseconds (estimated)
+    printf("total_parallel_cputime_ns = %lu (%0.2f seconds)\n", total_parallel_cputime_ns, total_parallel_cputime_ns / 1e9);
+
+    // total CPU time spent in critical (hold) in nanoseconds (estimated)
+    printf("total_critical_cputime_ns = %lu (%0.2f seconds)\n", total_critical_cputime_ns, total_critical_cputime_ns / 1e9);
+    }
+
+
+    // overhead metrics
+
+    s->total_lock_overhead_cputime_ns = total_lock_overhead_cputime_ns;
+    s->avg_lock_overhead_cputime_ns = avg_lock_overhead_cputime_ns;
+    s->lock_overhead_cputime_percent = lock_overhead_cputime_percent;
+
+    if (verbose >= VERBOSE_YES) {
+    printf("overhead metrics:________________________________________\n");
+
+    // total CPU time minus critical and parallel CPU time in nanoseconds
+    printf("total_lock_overhead_cputime_ns = %lu (%0.2f seconds)\n", total_lock_overhead_cputime_ns, total_lock_overhead_cputime_ns / 1e9);
+
+    // total lock overhead CPU time as a percentage of total CPU time
+    printf("lock_overhead_cputime_percent = %f%%\n", lock_overhead_cputime_percent);
+
+    // average lock overhead CPU time per lock acquire in nanoseconds
+    printf("avg_lock_overhead_cputime_ns = %f per lock acquire [overhead_ns]\n", avg_lock_overhead_cputime_ns);
+    }
+
+
+    // performance metrics
+
+    s->cputime_ns_per_lock_acquire = cputime_ns_per_lock_acquire;
+    s->wall_elapsed_ns_per_lock_acquire = wall_elapsed_ns_per_lock_acquire;
+    s->total_lock_acquires_per_second = total_lock_acquires_per_second;
+
+    if (verbose >= VERBOSE_YES) {
+    printf("performance metrics:_____________________________________\n");
+
+    // CPU time per lock acquire (includes critical and parallel time)
+    printf("cputime_ns_per_lock_acquire = %f [cpu_ns/lock]\n", cputime_ns_per_lock_acquire);
+
+    // wall clock elapsed time per lock acquire (includes critical and parallel time)
+    printf("wall_elapsed_ns_per_lock_acquire = %f\n", wall_elapsed_ns_per_lock_acquire);
+
+    // aggregate lock acquires per second
+    printf("total_lock_acquires_per_second = %f [locks/wall_sec]\n", total_lock_acquires_per_second);
+    }
+
+
+    // ratio metrics
+
+    s->cpu_to_wall_elapsed_ratio = cpu_to_wall_elapsed_ratio;
+    s->mean_lock_depth = mean_lock_depth;
+
+    if (verbose >= VERBOSE_YES) {
+    printf("ratio metrics:___________________________________________\n");
+
+    // total CPU time divded by total wall clock time
+    printf("cpu_to_wall_elapsed_ratio = %f\n", cpu_to_wall_elapsed_ratio);
+
+    // average lock depth per thread, where lock_depth depends on the lock implementation
+    printf("mean_lock_depth = %f\n", mean_lock_depth);
+    }
+
+    num_reports++;
+
+    if (0) {
+
+    // original output used
+    // "scheduled" to mean cpu time
+    // "real" to mean wall clock time
+    // "realcpu" to mean total of all threads' wall clock time
+    // "scheduled/real" to estimate cores.
+
+    fprintf(stderr, "%ld lock loops (lock acquires)\n", total_lock_acquires);
+    fprintf(stderr, "%ld ns CPU time\n", total_cputime_ns);
+    fprintf(stderr, "%f ns per lock acquire (cpu)\n", cputime_ns_per_lock_acquire);
+    fprintf(stderr, "%f ns access rate (wall clock time divided by total number of all lock attempts)\n", wall_elapsed_ns_per_lock_acquire);
+    fprintf(stderr, "%f average depth\n", mean_lock_depth);
+
+    printf("num_threads, cpu_ns/acquire, real/result, mean_lock_depth\n");
+    printf("%lu, %f, %f, %f\n",
+           num_threads,
+           cputime_ns_per_lock_acquire,
+           wall_elapsed_ns_per_lock_acquire,
+           mean_lock_depth);
+    }
+}
+
+
+#ifdef JSON_OUTPUT
+
+// floating point values not handled by standard JSON is recorded as strings
+static json_t * json_real_helper(double x) {
+    if (isnan(x)) {
+        return json_string("NaN");
+    }
+
+    switch(isinf(x)) {
+        case -1: return json_string("-Inf");
+        case  1: return json_string("+Inf");
+        default: break;
+    }
+    return json_real(x);
+}
+
+// invokes the corresponding function based on the type of x
+#define JOBJ(x) _Generic(x, \
+    double          : json_real_helper, \
+    const char *    : json_string, \
+    char *          : json_string, \
+    unsigned long   : json_integer ) (x)
+
+
+static json_t * json_get_one_pinorder_list(const pinorder_t * p) {
+    json_t * po_list = json_array();
+
+    for (size_t j = 0; j < p->num_threads; j++) {
+        json_t * json_cpu = json_integer(p->cpu_list[j]);
+        json_array_append_new(po_list, json_cpu);
+    }
+
+    return po_list;
+}
+
+
+static void json_output(test_args_t * args) {
+    const pinorder_t * p_pinorders = args->pinorders;
+    const size_t num_pinorders = args->num_pinorders;
+    const char * json_output_filename = args->json_output_filename;
+
+    if (json_output_filename == NULL) return;
+
+    char hostname[HOST_NAME_MAX+1];
+
+    gethostname(hostname, HOST_NAME_MAX);
+    hostname[HOST_NAME_MAX] = '\0'; // ensure null-termination
+
+    // setup pinorders json array object
+    // the index into this array is the pinorder number
+
+    json_t * json_pinorders = json_array();
+
+    for (size_t i = 0; i < num_pinorders; i++) {
+        const pinorder_t * p = &(p_pinorders[i]);
+        json_t * po_list = json_get_one_pinorder_list(p);
+
+        json_array_append_new(json_pinorders, po_list);
+    }
+
+    // setup results json array object
+
+    json_t * json_results = json_array();
+
+// this_json_root["dest_element"] = source_var
+#define JOS(this_json_root, dest_element, source_var) \
+    if (json_object_set_new(this_json_root, stringify(dest_element), JOBJ(source_var))) {\
+        fprintf(stderr, "json_object_set returned failure when setting " stringify(this_json_root) " " stringify(dest_element) "\n"); exit(-1); }
+
+// json_result["x"] = s->x
+#define S(x) \
+    JOS(json_result, x, s->x)               // XXX: note explicit use of a pointer named s
+
+// json_per_thread_stat["x"] = s->per_thread_stats[j].x
+#define T(x) \
+    JOS(json_per_thread_stat, x, s->per_thread_stats[j].x)  // XXX: note iteration using j
+
+    for (size_t i = 0; i < num_reports; i++) {
+        const report_data_t * s = &report_summary[i];
+
+        json_t * json_result = json_object();
+
+        // store the full CPU pinorder list in a result so that results between jsons can be compared a little bit more easily
+        const pinorder_t * p_pinorder = s->pinorder;
+        json_t * po_list = json_get_one_pinorder_list(p_pinorder);
+        json_object_set_new(json_result, "pinorder", po_list);
+
+        // store the pinorder number
+        json_object_set_new(json_result, "pinorder_number",
+             json_integer(p_pinorder - p_pinorders));
+
+        // store the per-thread stats as an array
+        json_t * json_per_thread_stats = json_array();
+
+        for (size_t j = 0; j < s->num_threads; j++) {
+            json_t * json_per_thread_stat = json_object();
+
+//          T(thread_num);    // instead of storing the thread_num, the index into this array is the thread_num.
+            T(cpu_num);
+            T(lock_acquires);
+            T(lock_acquires_sigmas);
+            T(lock_acquires_percent);
+            T(cpu_time_ns);
+            T(walltime_ns);
+            T(depth);
+            T(critical_ns_per_loop);
+            T(parallel_ns_per_loop);
+
+            // for precision, store the counter as a hex string instead of risking truncation by JSON parsers
+            char hwtimer_start_hex[32];
+            char hwtimer_end_hex[32];
+            snprintf(hwtimer_start_hex, sizeof(hwtimer_start_hex), "0x%lx", s->per_thread_stats[j].hwtimer_start);
+            snprintf(hwtimer_end_hex, sizeof(hwtimer_end_hex), "0x%lx", s->per_thread_stats[j].hwtimer_end);
+            JOS(json_per_thread_stat, hwtimer_start_hex, hwtimer_start_hex);
+            JOS(json_per_thread_stat, hwtimer_end_hex, hwtimer_end_hex);
+
+            json_array_append_new(json_per_thread_stats, json_per_thread_stat);
+        }
+        json_object_set_new(json_result, "per_thread_stats", json_per_thread_stats);
+
+        // test configuration
+        JOS(json_result, hostname, hostname);
+        S(test_name);
+        S(variant_name);
+        S(meas_number);
+        S(test_number);
+        S(iteration);
+        S(num_threads);
+        S(nominal_critical);
+        S(nominal_parallel);
+        S(nominal_critical_unit);
+        S(nominal_parallel_unit);
+        S(run_limit_num_acquires);
+        S(run_limit_ticks);
+        S(run_limit_seconds);
+        S(hwtimer_frequency);
+        S(probed_hwtimer_frequency);
+
+        // measurement accuracy metrics
+        S(avg_critical_ns_per_loop);
+        S(avg_parallel_ns_per_loop);
+        S(full_concurrency_fraction);
+        S(total_lock_acquires);
+        S(lock_acquires_mean);
+        S(lock_acquires_stddev);
+        S(lock_acquires_stddev_over_mean);
+
+        // duration metrics
+        S(wall_elapsed_ns);
+        S(total_cputime_ns);
+        S(total_parallel_cputime_ns);
+        S(total_critical_cputime_ns);
+
+        // derived lock overhead metrics
+        S(total_lock_overhead_cputime_ns);
+        S(avg_lock_overhead_cputime_ns);
+        S(lock_overhead_cputime_percent);
+
+        // performance metrics
+        S(cputime_ns_per_lock_acquire);
+        S(wall_elapsed_ns_per_lock_acquire);
+        S(total_lock_acquires_per_second);
+
+        // ratio metrics
+        S(cpu_to_wall_elapsed_ratio);
+        S(mean_lock_depth);
+
+        json_array_append_new(json_results, json_result);
+    }
+
+    // pack pinorders and results into root
+    json_t * root = json_pack("{soso}",
+            "pinorders", json_pinorders,
+            "results", json_results);
+
+    // output root as json file
+    printf("results are also saved to %s\n", json_output_filename);
+    int ret = json_dump_file(root, json_output_filename, JSON_SORT_KEYS | JSON_INDENT(4));
+    if (ret) { printf("json_dump_file returned %d\n", ret); }
+
+    json_decref(root);  // free everything
+}
+
+// undefine helper macros that are to be used only in json_output()
+#undef S
+#undef T
+#undef JOS
+
+#endif
+
+void print_summary(test_args_t * args) {
+    const pinorder_t * p_pinorders = args->pinorders;
+    const size_t num_pinorders = args->num_pinorders;
+    const int verbose = args->verbose;
+
+    printf("Finished running test_name=%s variant_name=%s\n", test_name, variant_name);
+
+    if (verbose >= VERBOSE_YES) {
+        printf("\n");
+        printf("---------------\n");
+        printf("Results Summary\n");
+        printf("---------------\n\n");
+
+        printf("pinorders:\n");
+    }
+    printf("po  cpus\n");
+    for (size_t i = 0; i < num_pinorders; i++) {
+        const pinorder_t * p = &(p_pinorders[i]);
+        printf("%-2zu ", i);
+        for (size_t j = 0; j < p->num_threads; j++) {
+            printf(" %d", p->cpu_list[j]);
+        }
+        printf("\n");
+    }
+    printf("\n");
+
+    if (verbose >= VERBOSE_YES)
+        printf("results by pinorder:\n");
+
+    printf("po  meas  test  iter  thrds | cpu_ns/lock - crit_ns - par_ns  = overhead_ns %% | lasom | locks/wall_sec\n");
+    for (size_t i = 0; i < num_reports; i++) {
+        report_data_t * s = &report_summary[i];
+        printf("%-2zu  ", (s->pinorder - p_pinorders));
+        printf("%-4zu  ", s->meas_number);
+        printf("%-4zu  ", s->test_number);
+        printf("%-4zu  ", s->iteration);
+        printf("%-5lu | ", s->num_threads);
+        printf("%-11.f   ", s->cputime_ns_per_lock_acquire);
+        printf("%-7.f   ", s->avg_critical_ns_per_loop);
+        printf("%-7.f   ", s->avg_parallel_ns_per_loop);
+//        printf("%8lu  ", s->total_lock_acquires);
+        printf("%-8.f ", s->avg_lock_overhead_cputime_ns);
+        printf("%3.f%% | ", s->lock_overhead_cputime_percent);
+        printf("%.3f | ", s->lock_acquires_stddev_over_mean);
+        printf("%.f", s->total_lock_acquires_per_second);
+        printf("\n");
+    }
+
+#ifdef JSON_OUTPUT
+    json_output(args);
+#endif
+
+    for (size_t i = 0; i < num_reports; i++) {
+        free(report_summary[i].per_thread_stats);
+    }
+    free(report_summary);
+}
+
+
+static int get_length(unsigned long x) {
+    char hwtimer_len_testbuf[100];
+    int length = snprintf(hwtimer_len_testbuf, sizeof(hwtimer_len_testbuf), "%lu", x);
+    return length;
+}
+
+static int calculate_hwtimer_len(unsigned long hwtimer_start_base, size_t num_threads) {
+    int max_len = 0;
+
+    for (size_t i = 0; i < num_threads; i++) {
+        per_thread_results_t * p = &thread_args[i].results;
+        unsigned long ticks_10p = p->hwtimer_10p - hwtimer_start_base;
+        unsigned long ticks_25p = p->hwtimer_25p - hwtimer_start_base;
+        unsigned long ticks_50p = p->hwtimer_50p - hwtimer_start_base;
+        unsigned long ticks_75p = p->hwtimer_75p - hwtimer_start_base;
+        unsigned long ticks_90p = p->hwtimer_90p - hwtimer_start_base;
+        unsigned long ticks_100p= p->hwtimer_end - hwtimer_start_base;
+
+        int len_10p = get_length(ticks_10p );
+        int len_25p = get_length(ticks_25p );
+        int len_50p = get_length(ticks_50p );
+        int len_75p = get_length(ticks_75p );
+        int len_90p = get_length(ticks_90p );
+        int len_100p= get_length(ticks_100p);
+
+        if (len_10p  > max_len) max_len = len_10p ;
+        if (len_25p  > max_len) max_len = len_25p ;
+        if (len_50p  > max_len) max_len = len_50p ;
+        if (len_75p  > max_len) max_len = len_75p ;
+        if (len_90p  > max_len) max_len = len_90p ;
+        if (len_100p > max_len) max_len = len_100p;
+    }
+
+#if 0
+    // the old way of estimating the width by measuring the counter magnitude
+    unsigned long hwtimer_now = timer_get_counter(); // XXX: this is just to get a display length of the hwtimer around now
+    int hwtimer_len = snprintf(hwtimer_len_testbuf, sizeof(hwtimer_len_testbuf), "%lu", hwtimer_now);
+#endif
+
+    return max_len;
+}
+
+
+// If the CNTVCT or equivalent hardware clock is globally synchronous
+// such that a simultaneous observation of it on one CPU returns the same
+// value as on another CPU, use it to compare the start and stop of
+// each thread's measurement to measure the workload overlap.
+void starting_stopping_time_report (unsigned long num_threads, unsigned long verbose, unsigned long num_acquires, pinorder_t * p_pinorder, unsigned long run_limit_ticks) {
+
+    size_t hwtimer_start_earliest_thread = -1;
+    size_t hwtimer_start_latest_thread = -1;
+    size_t hwtimer_end_earliest_thread = -1;
+    size_t hwtimer_end_latest_thread = -1;
+    unsigned long hwtimer_start_earliest = -1;
+    unsigned long hwtimer_start_latest = 0;
+    unsigned long hwtimer_end_earliest = -1;
+    unsigned long hwtimer_end_latest = 0;
+
+    unsigned long hwtimer_diff_shortest = -1;
+    unsigned long hwtimer_diff_longest = 0;
+
+    size_t hwtimer_diff_shortest_thread = -1;
+    size_t hwtimer_diff_longest_thread = -1;
+
+    for (size_t i = 0; i < num_threads; i++) {
+        hwtimer_diff[i] = thread_args[i].results.hwtimer_end - thread_args[i].results.hwtimer_start;
+
+        if (hwtimer_diff[i] > hwtimer_diff_longest) {
+            hwtimer_diff_longest = hwtimer_diff[i];
+            hwtimer_diff_longest_thread = i;
+        }
+
+        if (hwtimer_diff[i] < hwtimer_diff_shortest) {
+            hwtimer_diff_shortest = hwtimer_diff[i];
+            hwtimer_diff_shortest_thread = i;
+        }
+
+        if (thread_args[i].results.hwtimer_end > hwtimer_end_latest) {
+            hwtimer_end_latest = thread_args[i].results.hwtimer_end;
+            hwtimer_end_latest_thread = i;
+        }
+
+        if (thread_args[i].results.hwtimer_start > hwtimer_start_latest) {
+            hwtimer_start_latest = thread_args[i].results.hwtimer_start;
+            hwtimer_start_latest_thread = i;
+        }
+
+        if (thread_args[i].results.hwtimer_end < hwtimer_end_earliest) {
+            hwtimer_end_earliest = thread_args[i].results.hwtimer_end;
+            hwtimer_end_earliest_thread = i;
+        }
+
+        if (thread_args[i].results.hwtimer_start < hwtimer_start_earliest) {
+            hwtimer_start_earliest = thread_args[i].results.hwtimer_start;
+            hwtimer_start_earliest_thread = i;
+        }
+    }
+
+    setlocale(LC_NUMERIC, "en_US.UTF-8");
+
+    unsigned long hwtimer_frequency = timer_get_timer_freq();
+
+    if (verbose >= VERBOSE_MORE) {
+    printf("starting/stopping time report:___________________________\n");
+    printf("hwtimer_frequency = %'lu Hz (%.3f ns per tick)\n", hwtimer_frequency, 1e9/hwtimer_frequency);
+
+    // compute the spread of the measurement start of all threads
+    printf("hwtimer_start:  0x%lx .. 0x%lx (thread %zu .. %zu), spread = %'lu (%'.2f ns)\n",
+            hwtimer_start_earliest, hwtimer_start_latest,
+            hwtimer_start_earliest_thread, hwtimer_start_latest_thread,
+            hwtimer_start_latest - hwtimer_start_earliest,
+            (hwtimer_start_latest - hwtimer_start_earliest) * 1e9 / hwtimer_frequency
+          );
+
+    // compute the spread of the completion of all threads
+    printf("hwtimer_end:    0x%lx .. 0x%lx (thread %zu .. %zu), spread = %'lu (%'.2f ns)\n",
+            hwtimer_end_earliest, hwtimer_end_latest,
+            hwtimer_end_earliest_thread, hwtimer_end_latest_thread,
+            hwtimer_end_latest - hwtimer_end_earliest,
+            (hwtimer_end_latest - hwtimer_end_earliest) * 1e9 / hwtimer_frequency
+          );
+
+    // compute the spread of the durations of all threads
+    printf("hwtimer_diff: %lu (%'.3f ns) .. %lu (%'.3f ns) (thread %zu .. %zu), spread = %'lu (%'.3f ns), long/short = %0.3f\n",
+            hwtimer_diff_shortest, hwtimer_diff_shortest * 1e9 / hwtimer_frequency,
+            hwtimer_diff_longest, hwtimer_diff_longest * 1e9 / hwtimer_frequency,
+            hwtimer_diff_shortest_thread, hwtimer_diff_longest_thread,
+            hwtimer_diff_longest - hwtimer_diff_shortest,
+            (hwtimer_diff_longest - hwtimer_diff_shortest) * 1e9 / hwtimer_frequency,
+            hwtimer_diff_longest / (double) hwtimer_diff_shortest);
+    }
+
+    // compute statistics on the durations
+
+    double mean_hwtimer_diff = 0;
+    unsigned long hwtimer_diff_sum = 0;
+
+    for (size_t i = 0; i < num_threads; i++) {
+        hwtimer_diff_sum += hwtimer_diff[i];
+    }
+
+    mean_hwtimer_diff = ((double) hwtimer_diff_sum) / num_threads;
+
+    double sum_diff_squared = 0;
+    double mean_abs_diff = 0;
+
+    for (size_t i = 0; i < num_threads; i++) {
+        double diff = (hwtimer_diff[i] - mean_hwtimer_diff);
+        sum_diff_squared += diff * diff;
+
+        mean_abs_diff += fabs(diff);
+    }
+
+    sum_diff_squared /= num_threads;
+    mean_abs_diff /= num_threads;
+
+    double std_dev = sqrt(sum_diff_squared);
+
+    if (verbose >= VERBOSE_MORE)
+    printf("hwtimer_diff_stats:  mean = %.f (%'0.3f ns), mean_abs_diff = %0.3f, std_dev = %0.3f\n",
+            mean_hwtimer_diff, mean_hwtimer_diff * 1e9 / hwtimer_frequency, mean_abs_diff, std_dev);
+
+    // compute buckets against normal distribution
+
+    size_t neg_buckets[4] = {0};
+    size_t pos_buckets[4] = {0};
+
+    for (size_t i = 0; i < num_threads; i++) {
+        double diff = (hwtimer_diff[i] - mean_hwtimer_diff);
+        double sigmas = diff / std_dev;
+
+        long bucket = (long) sigmas;
+        if (bucket > 3)  { bucket = 3; }
+        if (bucket < -3) { bucket = -3; }
+
+        if (sigmas >= 0) {
+            pos_buckets[bucket]++;
+        } else {
+            neg_buckets[-bucket]++;
+        }
+
+        // printf("sigmas = %f, bucket = %ld\n", sigmas, bucket);
+    }
+
+    if (verbose >= VERBOSE_MORE) {
+    printf("hwtimer_diff_distribution: ");
+    printf("<-3sigma:%zu, ", neg_buckets[4 - 1]);
+    for (long sigma = 3; sigma >= 1; sigma--) {
+        printf("-%ld:%zu, ", sigma, neg_buckets[sigma - 1]);
+    }
+    for (long sigma = 1; sigma <  4; sigma++) {
+        printf("+%ld:%zu, ", sigma, pos_buckets[sigma - 1]);
+    }
+    printf( ">+3sigma:%zu\n", pos_buckets[4 - 1]);
+    }
+
+
+#ifdef PROGRESS_TICK_PROFILE
+    // print hwtimer tick on each thread at quarter intervals
+
+    const int print_ticks_relative_to_earliest = 1;
+    unsigned long hwtimer_start_base = print_ticks_relative_to_earliest ? hwtimer_start_earliest : 0;
+    int hwtimer_len = calculate_hwtimer_len(hwtimer_start_base, num_threads);
+
+    if (run_limit_ticks == 0 && verbose >= VERBOSE_MORE) { // only do this for -a num_acquires mode
+        printf("progress tick profile; < is printed for ticks that are later than the first finishing worker's 100%% tick\n");
+        printf("for 0%% and 100%%: ^ for earliest, $ for latest\n");
+        printf("thread\t%*s  %*s  %*s  %*s  %*s  %*s  %*s  75%% rate (ns/acq)\n",
+            hwtimer_len+1,"0%",
+            hwtimer_len,  "10%",
+            hwtimer_len,  "25%",
+            hwtimer_len,  "50%",
+            hwtimer_len+1,"75%",
+            hwtimer_len+1,"90%",
+            hwtimer_len+1,"100%");
+
+        for (size_t i = 0; i < num_threads; i++) {
+            per_thread_results_t * p = &thread_args[i].results;
+            unsigned long ticks_10p = p->hwtimer_10p - p->hwtimer_start;
+            unsigned long ticks_25p = p->hwtimer_25p - p->hwtimer_start;
+            unsigned long ticks_50p = p->hwtimer_50p - p->hwtimer_start;
+            unsigned long ticks_75p = p->hwtimer_75p - p->hwtimer_start;
+            unsigned long ticks_90p = p->hwtimer_90p - p->hwtimer_start;
+            unsigned long ticks_100p= p->hwtimer_end - p->hwtimer_start;
+
+            unsigned long ticks_10p_90p = p->hwtimer_90p - p->hwtimer_10p;
+            double lock_acquire_rate = ticks_10p_90p * 1e9 / (0.8 * num_acquires * hwtimer_frequency);
+
+            double lock_acquire_rate_75p = (p->hwtimer_75p - p->hwtimer_start) * 1e9 / (0.75 * num_acquires * hwtimer_frequency);
+            // "lock acquire rate" is not acquires per second, it is ns per acquire.
+
+            printf("%zu\t", i);
+
+            if (0)  // don't want to remove it just yet, maybe useful in the future
+            printf("%lu\t%lu\t%lu\t%lu\t%lu\t%lu\t%.f\t\t",
+                 ticks_10p, ticks_25p, ticks_50p, ticks_75p, ticks_90p, ticks_100p, lock_acquire_rate);
+
+            printf("%*lu%c %*lu%c %*lu%c %*lu%c %*lu%c %*lu%c %*lu%c %.f\n",
+                hwtimer_len+1, p->hwtimer_start - hwtimer_start_base, denote_end(p->hwtimer_start, thread_args, num_threads, hwtimer_start_earliest, hwtimer_start_latest),
+                hwtimer_len, p->hwtimer_10p - hwtimer_start_base, is_earlier_than_range(p->hwtimer_10p, thread_args, num_threads),   // XXX: does this ever happen?
+                hwtimer_len, p->hwtimer_25p - hwtimer_start_base, is_later_than_range(p->hwtimer_25p, thread_args, num_threads),
+                hwtimer_len, p->hwtimer_50p - hwtimer_start_base, is_later_than_range(p->hwtimer_50p, thread_args, num_threads),
+                hwtimer_len+1, p->hwtimer_75p - hwtimer_start_base, is_later_than_range(p->hwtimer_75p, thread_args, num_threads),
+                hwtimer_len+1, p->hwtimer_90p - hwtimer_start_base, is_later_than_range(p->hwtimer_90p, thread_args, num_threads),
+                hwtimer_len+1, p->hwtimer_end - hwtimer_start_base, denote_end(p->hwtimer_end, thread_args, num_threads, hwtimer_end_earliest, hwtimer_end_latest),
+                lock_acquire_rate_75p);
+        }
+    }
+#endif
+
+// #define OSQ_LOCK_COUNT_LOOPS   // enable this here and in osq_lock.h to show loop counts
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    printf("osq_lock per-cpu loop counts:\n");
+    printf("thread cpu  %20s %22s %17s %18s %22s\n", "lock_wait_next_spins", "unlock_wait_next_spins", "lock_locked_spins", "lock_unqueue_spins", "lock_acquire_backoffs");
+    for (size_t i = 0; i < num_threads; i++) {
+        per_thread_results_t * p = &thread_args[i].results;
+        printf("%6zu %3d  %20lu %22lu %17lu %18lu %22lu\n",
+                i, p_pinorder->cpu_list[i],
+                p->osq_lock_wait_next_spins,
+                p->osq_unlock_wait_next_spins,
+                p->osq_lock_locked_spins,
+                p->osq_lock_unqueue_spins,
+                p->osq_lock_acquire_backoffs);
+    }
+#endif
+
+}
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/tests/cas_lockref.h
+++ b/benchmarks/lockhammer/tests/cas_lockref.h
@@ -30,6 +30,7 @@
  */
 
 #include "atomics.h"
+#include "cpu_relax.h"
 
 static inline unsigned long lock_acquire (uint64_t *lock, unsigned long threadnum) {
 	unsigned long val, old;
@@ -44,7 +45,11 @@ static inline unsigned long lock_acquire (uint64_t *lock, unsigned long threadnu
 		}
 
 		val = cas64(lock, val, old);
-	} while (val != old);
+		if (val == old) {
+			break;
+		}
+		__cpu_relax();
+	} while (1);
 
 	return val >> 32;
 }
@@ -62,5 +67,11 @@ static inline void lock_release (uint64_t *lock, unsigned long threadnum) {
 		}
 
 		val = cas64(lock, val, old);
-	} while (val != old);
+		if (val == old) {
+			return;
+		}
+		__cpu_relax();
+	} while (1);
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab: */

--- a/benchmarks/lockhammer/tests/cas_rw_lock.h
+++ b/benchmarks/lockhammer/tests/cas_rw_lock.h
@@ -33,7 +33,7 @@
 #undef initialize_lock
 #endif
 
-#define initialize_lock(lock, threads) cas_rw_lock_init(lock, threads)
+#define initialize_lock(lock, pinorder, threads) cas_rw_lock_init(lock, threads)
 #define CAS_RW_INIT_VAL 0x20000000
 #define CAS_RW_THRESHOLD 0
 
@@ -66,3 +66,5 @@ static inline unsigned long lock_acquire (uint64_t *lock, unsigned long threadnu
 static inline void lock_release (uint64_t *lock, unsigned long threadnum) {
 	fetchadd64_release(lock, 1);
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab: */

--- a/benchmarks/lockhammer/tests/incdec_refcount.h
+++ b/benchmarks/lockhammer/tests/incdec_refcount.h
@@ -38,3 +38,5 @@ static inline unsigned long lock_acquire (uint64_t *lock, unsigned long threadnu
 static inline void lock_release (uint64_t *lock, unsigned long threadnum) {
 	fetchsub64(lock, 1ul);
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab: */

--- a/benchmarks/lockhammer/tests/swap_mutex.h
+++ b/benchmarks/lockhammer/tests/swap_mutex.h
@@ -44,3 +44,5 @@ static inline unsigned long lock_acquire (uint64_t *lock, unsigned long threadnu
 static inline void lock_release (uint64_t *lock, unsigned long threadnum) {
 	__atomic_store_n(lock, 0, __ATOMIC_RELEASE);
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab: */

--- a/ext/jvm/jvm_objectmonitor.h
+++ b/ext/jvm/jvm_objectmonitor.h
@@ -30,14 +30,18 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <time.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdarg.h>
 
 #ifdef initialize_lock
 #undef initialize_lock
 #endif
 
-#define initialize_lock(lock, threads) jvm_init_locks(lock, threads);
+#define initialize_lock(lock, pinorder, num_threads) jvm_init_locks(lock, num_threads);
 
 #include "atomics.h"
+#include "cpu_relax.h"
 
 /*
  * jvm_objectmonitor.h: A model of the OpenJDK ObjectMonitor class.
@@ -100,10 +104,8 @@
  *      should be the same code in the end).
  *   2) This code mainly uses pthread_ts to track the individual
  *      threads, while the JVM uses various Thread-derived objects.
- *      Since ObjectWaiter has some of the data structures that the
- *      Thread classes have, this shouldn't be a big issue (and it
- *      keeps us from having to add more initialization code to
- *      generate the Thread structures).
+ *   3) ParkEvents are made/remade per thread in an array at each
+ *      measurement init instead of being recycled from a freelist.
  */
 
 /*
@@ -115,25 +117,192 @@
 /* Maximum time to park and recheck a parked thread. */
 #define MAX_RECHECK_INTERVAL 1000
 
+/* Define to use the lock pointer from lockhammer for the omonitor. */
+#define USE_LOCK_POINTER
+
+/* Define to malloc ObjectWaiters instead of how it's a stack object in jdk9 */
+//#define MALLOC_OBJECTWAITER
+
 /* Synchronize as the JVM does it... */
 #define FULL_MEM_BARRIER do { __sync_synchronize(); } while(0)
 #define READ_MEM_BARRIER do { __atomic_thread_fence(__ATOMIC_ACQUIRE); } while(0)
 #define WRITE_MEM_BARRIER do { __atomic_thread_fence(__ATOMIC_RELEASE); } while(0)
+
+// -----------------------
+// debugging functions
+
+static void report_vm_error(const char* detail_fmt, ...) {
+    va_list detail_args;
+    va_start(detail_args, detail_fmt);
+    vprintf(detail_fmt, detail_args);
+    va_end(detail_args);
+}
+
+// "guarantee() is like vmassert except it's always executed -- use it for
+// cheap tests that catch errors that would otherwise be hard to find."
+
+// The 'always executed' part should affect some code generation in contrast
+// with using assert(), which would not execute it with NDEBUG defined.
+
+// Note use of double-hash ##__VA_ARGS__, a GNU CPP extension that omits
+// the trailing comma when no variable arguments are given to the macro.
+
+#define BREAKPOINT  abort()
+
+#define guarantee(p, ...)                                                         \
+do {                                                                              \
+  if (__builtin_expect(!(p), 0)) {                                                \
+    report_vm_error(stringify(__FILE__) " line " stringify(__LINE__) " guarantee(" #p ") failed\n", ##__VA_ARGS__); \
+    BREAKPOINT;                                                                   \
+  }                                                                               \
+} while (0)
+
+// XXX: define NDEBUG_GUARANTEE to remove the compulsory evaluations for guarantee().
+//#define NDEBUG_GUARANTEE
+#ifdef NDEBUG_GUARANTEE
+#undef guarantee
+#define guarantee(p, ...)    (void) (0)
+#endif
+
+
+// XXX: redefine assert() to take a message argument
+// Note: NDEBUG is set in Makefile
+#ifdef NDEBUG
+#undef assert
+#define assert(p, ...)    (void) (0)
+#else
+#undef assert
+#define assert(p, ...) \
+do {                                                                              \
+  if (__builtin_expect(!(p), 0)) {                                                \
+    report_vm_error(stringify(__FILE__) " line " stringify(__LINE__) " assert(" #p ") failed\n", ##__VA_ARGS__); \
+    BREAKPOINT;                                                                   \
+  }                                                                               \
+} while (0)
+#endif
+
+
+// ---------------------------
+// data structure definitions
+
+// ParkEvent is in the Thread object, so it is persistent through a measurement.
+struct ParkEvent {
+    // os::PlatformEvent base class members
+    double CachePad[4]; // increase odds that _mutex is sole occupant of cache line (dubious)
+    volatile int _Event;
+    volatile int _nParked;
+    pthread_mutex_t _mutex[1];
+    pthread_cond_t _cond[1];
+    double PostPad[2];
+    pthread_t _Assoc;
+
+    // ParkEvent members
+    struct ParkEvent * FreeNext;
+    pthread_t AssociatedWith;
+    struct ParkEvent volatile * ListNext;
+
+    volatile intptr_t OnList;
+    volatile int TState;
+    volatile int Notified;
+};
+
+/* Possible ObjectWaiter states.  Not all of them are used. */
+enum TStates { TS_UNDEF, TS_READY, TS_RUN, TS_WAIT, TS_ENTER, TS_CXQ };
+//             0         1         2       3          4       5
+
+
+/*
+ * ObjectWaiter keeps track of a thread over a lock_acquire/lock_release pair.
+ */
+
+struct ObjectWaiter {
+    struct ObjectWaiter* volatile _next;
+    struct ObjectWaiter* volatile _prev;
+    pthread_t          _thread;
+    long               _notifier_tid;   // unused
+    struct ParkEvent * _event;
+    volatile int       _notified;       // unused
+    volatile enum TStates TState;
+    int                _Sorted;         // unused
+    char               _active;         // unused
+};
+
+/*
+ * Represents the ObjectMonitor object over in the JVM.  The recursion
+ * checks have been stripped out to simplify the code.
+ *
+ * Note that some fields in here (_SpinDuration) aren't protected
+ * by a mutex, because the JVM don't care.  Some (_SpinDuration) are
+ * kinda-sorta protected, but again -- the JVM don't care.
+ *
+ * There are more fields in the class that are not defined here.
+ *
+ * The relative offset of certain fields is important for functionality
+ * and performance in the VM, but the nuances have not been exactly reproduced.
+ */
+
+struct ObjectMonitor {
+    pthread_t volatile _owner;                  // monitor-owning thread
+    struct ObjectWaiter* volatile _EntryList;   // (Waitnodes acting as proxy for) Threads blocked on entry or reentry.
+    struct ObjectWaiter* volatile _cxq;         // LL of recently-arrived threads blocked on entry.
+    pthread_t volatile _succ;                   // Heir presumptive thread - used for futile wakeup throttling
+    pthread_t volatile _Responsible;            // thread that will periodically unpark
+
+    volatile int _Spinner;                      // for exit->spinner handoff optimization (not used in this benchmark)
+    volatile int _SpinDuration;                 /* JVM doesn't protect this ... fiiine... */
+    volatile int _count;                        // count of threads who have entered monitor
+};
+
+size_t park_events_length = 0;
+struct ParkEvent * park_events = NULL;
 
 inline static void release_store_thread(volatile pthread_t* dest,
         pthread_t val) {
     __atomic_store_n(dest, val, __ATOMIC_RELEASE);
 }
 
-inline static void storeload(void) {
-    FULL_MEM_BARRIER;
+#if __x86_64__
+inline static void OrderAccess_compiler_barrier(void) {
+    __asm__ volatile ("" : : : "memory");
 }
 
+inline static void OrderAccess_fence(void) {
+    __asm__ volatile ("lock; addl $0,0(%%rsp)" : : : "cc", "memory");
+    OrderAccess_compiler_barrier();
+}
+#endif
+
+#ifdef __aarch64__
+inline static void OrderAccess_fence(void) {
+    FULL_MEM_BARRIER;
+}
+#endif
+
+inline static void storeload(void) {
+    OrderAccess_fence();
+}
+
+// for Atomic::xchg()
+#if __x86_64__
+inline int     Atomic__xchg    (int     exchange_value, volatile int*     dest) {
+    __asm__ volatile (  "xchgl (%2),%0"
+                      : "=r" (exchange_value)
+                      : "0" (exchange_value), "r" (dest)
+                      : "memory");
+    return exchange_value;
+}
+
+inline static int int_xchg(int exchange_value, volatile int* dest) {
+    return Atomic__xchg(exchange_value, dest);
+}
+#elif defined(__aarch64__)
 inline static int int_xchg(int exchange_value, volatile int* dest) {
     int res = __sync_lock_test_and_set(dest, exchange_value);
     FULL_MEM_BARRIER;
     return res;
 }
+#endif
+
 /*
  * Couple of cmpxchg calls used by the JVM.  This filters down to the
  * os/cpu levels of the code, where we finally get to the actual
@@ -141,22 +310,26 @@ inline static int int_xchg(int exchange_value, volatile int* dest) {
  *
  * There's one implementation for pthread_t and the other for int.
  */
+
+// Atomic::cmpxchg_ptr  --> o_thread_cmpxchg
 inline pthread_t o_thread_cmpxchg(pthread_t exchange_value,
-        volatile pthread_t* dest,
-        pthread_t compare_value) {
+        volatile pthread_t* dest, pthread_t compare_value) {
     return __sync_val_compare_and_swap(dest, compare_value, exchange_value);
 }
 
+// Atomic::cmpxchg --> o_int_cmpxchg
 inline int o_int_cmpxchg(int exchange_value, volatile int* dest,
         int compare_value) {
     return __sync_val_compare_and_swap(dest, compare_value, exchange_value);
 }
 
-inline void atomic_int_inc(volatile int* dest) {
-    __sync_add_and_fetch(dest, 1);
+// returns the updated value
+inline int atomic_int_inc(volatile int* dest) {
+    return __sync_add_and_fetch(dest, 1);
 }
-inline void atomic_int_dec(volatile int* dest) {
-    __sync_add_and_fetch(dest, -1);
+
+inline int atomic_int_dec(volatile int* dest) {
+    return __sync_add_and_fetch(dest, -1);
 }
 
 /*
@@ -184,6 +357,7 @@ static struct timespec* compute_abstime(struct timespec* abstime,
 
     struct timespec now;
     int status = clock_gettime(CLOCK_MONOTONIC, &now);
+    (void) status;
     abstime->tv_sec = now.tv_sec  + seconds;
     long nanos = now.tv_nsec + millis * NANOSECS_PER_MILLISEC;
     if (nanos >= NANOSECS_PER_SEC) {
@@ -194,30 +368,58 @@ static struct timespec* compute_abstime(struct timespec* abstime,
     return abstime;
 }
 
-/* Possible ObjectWaiter states.  Not all of them are used. */
-enum TStates { TS_UNDEF, TS_READY, TS_RUN, TS_WAIT, TS_ENTER, TS_CXQ };
 
-/*
- * Used to keep track of a waiting thread.
- */
-struct ObjectWaiter {
-    struct ObjectWaiter* volatile _next;
-    struct ObjectWaiter* volatile _prev;
-    pthread_t _thread;
-    volatile enum TStates _state;
-    /* Merged in os::PlatformEvent below, so I don't have to
-     * keep track of that separately.
-     */
-    volatile int _Event;
-    volatile int _nParked;
-    pthread_mutex_t _mutex;
-    pthread_cond_t _cond;
-};
+#if 0
+// unused
+void parkevent_reset(struct ParkEvent * p) {
+    // actually PlatformEvent::reset()
+    p->_Event = 0;
+}
 
+void parkevent_associate(struct ParkEvent * p, pthread_t thisThread) {
+    parkevent_reset(p);
+    p->AssociatedWith = thisThread;
+}
+#endif
+
+void parkevent_init(struct ParkEvent *p) {
+    int status; (void) status;
+
+    // os::PlatformEvent constructor init
+    pthread_condattr_t * attr = NULL;
+    status = pthread_cond_init(p->_cond, attr); // XXX: is attr=NULL OK?
+    assert(status == 0, "cond_init");
+    status = pthread_mutex_init(p->_mutex, NULL);
+    assert(status == 0, "mutex_init");
+    p->_Event = 0;
+    p->_nParked = 0;
+    p->_Assoc = NO_THREAD;
+
+    // ParkEvent constructor init
+    p->FreeNext = NULL;
+    p->AssociatedWith = NO_THREAD;
+    p->ListNext = NULL;
+    p->OnList = 0;
+    p->TState = 0;
+    p->Notified = 0;
+}
+
+void parkevent_destroy(struct ParkEvent *p) {
+    int status; (void) status;
+    status = pthread_cond_destroy(p->_cond);
+    assert(status == 0, "cond_destroy");
+    status = pthread_mutex_destroy(p->_mutex);
+    assert(status == 0, "mutex_destroy");
+    parkevent_init(p);
+}
+
+
+/* -- this function is not used
 inline intptr_t o_ptr_cmpxchg(intptr_t exchange_value, intptr_t* volatile dest,
         intptr_t compare_value) {
     return __sync_val_compare_and_swap(dest, compare_value, exchange_value);
 }
+*/
 
 inline struct ObjectWaiter* o_ow_cmpxchg(struct ObjectWaiter* exchange_value,
         struct ObjectWaiter* volatile *dest,
@@ -225,104 +427,179 @@ inline struct ObjectWaiter* o_ow_cmpxchg(struct ObjectWaiter* exchange_value,
     return __sync_val_compare_and_swap(dest, compare_value, exchange_value);
 }
 
-struct ObjectWaiter* initializeObjectWaiter(pthread_t thisThread) {
+#ifdef MALLOC_OBJECTWAITER
+struct ObjectWaiter* initializeObjectWaiter(pthread_t thisThread, struct ParkEvent * pe) {
     /* Really miss C++ ctors about now... */
-    struct ObjectWaiter *obj =
-            (struct ObjectWaiter*)malloc(sizeof(struct ObjectWaiter));
+    struct ObjectWaiter *obj;
+    if (posix_memalign((void *) &obj, 64, sizeof(struct ObjectWaiter))) {
+        fprintf(stderr, "jvm_objectmonitor posix_memalign failed allocating struct ObjectWaiter\n");
+        exit(-1);
+    }
+
     obj->_next = NULL;
     obj->_prev = NULL;
     obj->_thread = thisThread;
-    obj->_state = TS_RUN;
-    obj->_Event = 0;
-    obj->_nParked = 0;
-    pthread_mutex_init(&obj->_mutex, NULL);
-    pthread_cond_init(&obj->_cond, NULL);
+    obj->TState = TS_RUN;
+    obj->_event = pe;
+    parkevent_init(pe);
     return obj;
 }
+#endif
 
 void cleanupObjectWaiter(struct ObjectWaiter *obj) {
+#ifdef MALLOC_OBJECTWAITER
     free(obj);
+#else
+    // do nothing, because ObjectWaiter is allocated on the stack.
+#endif
 }
 
-/* Park the thread until explicitly unparked by another. */
-void parkObjectWaiter(struct ObjectWaiter *obj) {
+// ParkEvent base class is os::PlatformEvent.
+
+// XXX: ParkEvent is 256 byte-aligned using placement new.
+// In LH, this is effected using posix_memalign in jvm_init_locks().
+
+// hotspot/src/os/linux/vm/os_linux.cpp void os::PlatformEvent::park()
+// refers to the comments in os_solaris.cpp.
+
+// From: hotspot/src/os/solaris/vm/os_solaris.cpp
+
+// ObjectMonitor park-unpark infrastructure ...
+//
+// We implement Solaris and Linux PlatformEvents with the
+// obvious condvar-mutex-flag triple.
+// Another alternative that works quite well is pipes:
+// Each PlatformEvent consists of a pipe-pair.
+// The thread associated with the PlatformEvent
+// calls park(), which reads from the input end of the pipe.
+// Unpark() writes into the other end of the pipe.
+// The write-side of the pipe must be set NDELAY.
+// Unfortunately pipes consume a large # of handles.
+// Native solaris lwp_park() and lwp_unpark() work nicely, too.
+// Using pipes for the 1st few threads might be workable, however.
+//
+// park() is permitted to return spuriously.
+// Callers of park() should wrap the call to park() in
+// an appropriate loop.  A litmus test for the correct
+// usage of park is the following: if park() were modified
+// to immediately return 0 your code should still work,
+// albeit degenerating to a spin loop.
+//
+// In a sense, park()-unpark() just provides more polite spinning
+// and polling with the key difference over naive spinning being
+// that a parked thread needs to be explicitly unparked() in order
+// to wake up and to poll the underlying condition.
+//
+// Assumption:
+//    Only one parker can exist on an event, which is why we allocate
+//    them per-thread. Multiple unparkers can coexist.
+//
+// _Event transitions in park()
+//   -1 => -1 : illegal
+//    1 =>  0 : pass - return immediately
+//    0 => -1 : block; then set _Event to 0 before returning
+//
+// _Event transitions in unpark()
+//    0 => 1 : just return
+//    1 => 1 : just return
+//   -1 => either 0 or 1; must signal target thread
+//         That is, we can safely transition _Event from -1 to either
+//         0 or 1.
+//
+// _Event serves as a restricted-range semaphore.
+//   -1 : thread is blocked, i.e. there is a waiter
+//    0 : neutral: thread is running or ready,
+//        could have been signaled after a wait started
+//    1 : signaled - thread is running or ready
+//
+
+
+
+// Park the thread until explicitly unparked by another.
+// Only the thread associated with the Event/PlatformEvent may call park().
+
+void park(struct ParkEvent * pe) {
+    assert(pe->_nParked == 0, "invariant");
     int v;
     for (;;) {
-        v = obj->_Event;
-        if (o_int_cmpxchg(v-1, &obj->_Event, v) == v) break;
+        v = pe->_Event;
+        // store v-1 into pe->_Event if *pe->_Event has the value of v.
+        if (o_int_cmpxchg(v-1, &pe->_Event, v) == v) break;
     }
-    if (v == 0) {
-        int status = pthread_mutex_lock(&obj->_mutex);
-        ++obj->_nParked;
-        while (obj->_Event < 0) {
-            status = pthread_cond_wait(&obj->_cond, &obj->_mutex);
+    guarantee(v >= 0, "invariant");
+    if (v == 0) {   // i.e. pe->_Event was 0.
+        int status = pthread_mutex_lock(pe->_mutex);
+        assert(status == 0, "mutex_lock");
+        guarantee(pe->_nParked == 0, "invariant");
+        ++pe->_nParked;
+        while (pe->_Event < 0) {
+            status = pthread_cond_wait(pe->_cond, pe->_mutex);
+            // NB: ETIME is not a documented return value for pthread_cond_wait, but jdk-9 checks for it anyway....
             if (status == ETIME) { status = EINTR; }
+            assert(status == 0 || status == EINTR, "cond_wait");
         }
-        --obj->_nParked;
-        obj->_Event = 0;
-        status = pthread_mutex_unlock(&obj->_mutex);
-        FULL_MEM_BARRIER;
+        --pe->_nParked;
+        pe->_Event = 0;
+        status = pthread_mutex_unlock(pe->_mutex);
+        assert(status == 0, "mutex_unlock");
+        OrderAccess_fence();
     }
+    guarantee(pe->_Event >= 0, "invariant");
 }
 
 /* Park the thread until either another thread wakes us up, or until
  * the interval has expired.
  */
-void parkObjectWaiterTimed(struct ObjectWaiter *obj, int recheckInterval) {
+void parkTimed(struct ParkEvent * pe, long recheckInterval) {
+    guarantee(pe->_nParked == 0, "invariant");
     int v;
     for (;;) {
-        v = obj->_Event;
-        if (o_int_cmpxchg(v-1, &obj->_Event, v) == v) break;
+        v = pe->_Event;
+        if (o_int_cmpxchg(v-1, &pe->_Event, v) == v) break;
     }
-    if (v != 0) return;
+    guarantee(v >= 0, "invariant");
+    if (v != 0) return; // XXX: the original returns OS_OK here
 
     struct timespec abst;
     compute_abstime(&abst, recheckInterval);
-    int status = pthread_mutex_lock(&obj->_mutex);
-    ++obj->_nParked;
-    while (obj->_Event < 0) {
-        status = pthread_cond_timedwait(&obj->_cond, &obj->_mutex, &abst);
+    int status = pthread_mutex_lock(pe->_mutex);
+    assert(status == 0, "mutex_lock");
+    guarantee(pe->_nParked == 0, "invariant");
+    ++pe->_nParked;
+    while (pe->_Event < 0) {
+        status = pthread_cond_timedwait(pe->_cond, pe->_mutex, &abst);
+        assert(status == 0 || status == EINTR ||
+                  status == ETIME || status == ETIMEDOUT,
+                  status, "cond_timedwait");
         if (status == ETIME || status == ETIMEDOUT) break;
         // We consume and ignore EINTR and spurious wakeups.
     }
-    --obj->_nParked;
-    obj->_Event = 0;
-    status = pthread_mutex_unlock(&obj->_mutex);
-    FULL_MEM_BARRIER;
+    --pe->_nParked;
+    pe->_Event = 0;
+    status = pthread_mutex_unlock(pe->_mutex);
+    assert(status == 0, "mutex_unlock");
+    assert(pe->_nParked == 0, "invariant");
+    OrderAccess_fence();
     return;
 }
 
-/* Unpark the specified thread. */
-void unparkObjectWaiter(struct ObjectWaiter *node) {
-    if (int_xchg(1, &node->_Event) >= 0) {
+/* Unpark the specified ParkEvent. */
+void unpark(struct ParkEvent * pe) {
+    if (int_xchg(1, &pe->_Event) >= 0) {
         return;
     }
-    int status = pthread_mutex_lock(&node->_mutex);
-    int AnyWaiters = node->_nParked;
-    pthread_mutex_unlock(&node->_mutex);
+    int status; (void) status;
+    status = pthread_mutex_lock(pe->_mutex);
+    assert(status == 0, "mutex_lock");
+    int AnyWaiters = pe->_nParked;
+    assert(AnyWaiters == 0 || AnyWaiters == 1, "invariant");
+    status = pthread_mutex_unlock(pe->_mutex);
+    assert(status == 0, "mutex_lock");
     if (AnyWaiters != 0) {
-        status = pthread_cond_signal(&node->_cond);
+        status = pthread_cond_signal(pe->_cond);
+        assert(status == 0, "cond_signal");
     }
 }
-
-/*
- * Represents the ObjectMonitor object over in the JVM.  The recursion
- * checks have been stripped out to simplify the code.
- *
- * Note that some fields in here (_SpinDuration) aren't protected
- * by a mutex, because the JVM don't care.  Some (_SpinDuration) are
- * kinda-sorta protected, but again -- the JVM don't care.
- */
-struct ObjectMonitor {
-    pthread_t volatile _owner;
-    struct ObjectWaiter* volatile _EntryList;
-    struct ObjectWaiter* volatile _cxq;
-    volatile int _Spinner;
-    volatile int _SpinDuration; /* JVM doesn't protect this ... fiiine... */
-    volatile int _count;
-    pthread_t volatile _succ;
-    pthread_t volatile _Responsible;
-};
 
 /* Various tunings from the ObjectMonitor class. We're taking the defaults,
  * and we're not implementing the experimental command-line options.  You'll
@@ -351,11 +628,17 @@ static int Knob_ExitPolicy = 0;
 static int Knob_QMode = 0;
 
 /* The actual, real ObjectMonitor we'll use. */
-struct ObjectMonitor *omonitor;
+struct ObjectMonitor *omonitor = NULL;
 
-/* Yeah -- this is the actual implementation over in the JVM... */
 static inline int SpinPause(void) {
+    __cpu_relax();
+#ifdef __aarch64__
     return 0;
+#elif __x86_64__
+    return 1;
+#else
+#error "unsupported instruction set architecture"
+#endif
 }
 
 /* If we're in one of the queues, then we'll want to get out of it.
@@ -363,27 +646,49 @@ static inline int SpinPause(void) {
  * that cleanup of the ObjectWaiter that gets removed is done by the
  * caller.
  */
-void UnlinkAfterAcquire(pthread_t thisThread, struct ObjectWaiter *node) {
-    if (node->_state == TS_ENTER) {
-        struct ObjectWaiter *nxt = node->_next;
-        struct ObjectWaiter *prv = node->_prev;
+void UnlinkAfterAcquire(pthread_t thisThread, struct ObjectWaiter *SelfNode) {
+
+    assert(omonitor->_owner == thisThread, "invariant");
+    assert(SelfNode->_thread == thisThread, "invariant");
+
+    if (SelfNode->TState == TS_ENTER) {
+        struct ObjectWaiter *nxt = SelfNode->_next;
+        struct ObjectWaiter *prv = SelfNode->_prev;
         if (nxt != NULL) nxt->_prev = prv;
         if (prv != NULL) prv->_next = nxt;
-        if (node == omonitor->_EntryList) omonitor->_EntryList = nxt;
+        if (SelfNode == omonitor->_EntryList) omonitor->_EntryList = nxt;
+        assert(nxt == NULL || nxt->TState == TS_ENTER, "invariant");
+        assert(prv == NULL || prv->TState == TS_ENTER, "invariant");
     } else {
+        assert(SelfNode->TState == TS_CXQ, "invariant");
         struct ObjectWaiter *v = omonitor->_cxq;
-        if ((v != node) || (o_ow_cmpxchg(node->_next, &omonitor->_cxq, v) != v)) {
-            if (v == node) {
+        assert(v != NULL, "invariant");
+        if ((v != SelfNode) || (o_ow_cmpxchg(SelfNode->_next, &omonitor->_cxq, v) != v)) {
+            if (v == SelfNode) {
+                assert(omonitor->_cxq != v, "invariant");
                 v = omonitor->_cxq;
             }
             struct ObjectWaiter *p;
             struct ObjectWaiter *q = NULL;
-            for (p = v; p != NULL && p != node; p = p->_next) {
+            for (p = v; p != NULL && p != SelfNode; p = p->_next) {
                 q = p;
+                assert(p->TState == TS_CXQ, "invariant");
             }
+            assert(v != SelfNode, "invariant");
+            assert(p == SelfNode, "Node not found on cxq");
+            assert(p != omonitor->_cxq, "invariant");
+            assert(q != NULL, "invariant");
+            assert(q->_next == p, "invariant");
             q->_next = p->_next;
         }
     }
+
+#ifndef NDEBUG
+    // if assert() is enabled
+    SelfNode->_prev  = (struct ObjectWaiter *) 0xBAD;
+    SelfNode->_next  = (struct ObjectWaiter *) 0xBAD;
+    SelfNode->TState = TS_RUN;
+#endif
 }
 
 /*
@@ -397,13 +702,15 @@ static int Adjust(volatile int *adr, int dx) {
 }
 
 /*
- * Try to grab the lock.  See ObjectMonitor::TryLock().
+ * Try to grab the lock (i.e., insert thisThread into monitor->_owner).
+ * See ObjectMonitor::TryLock().
  */
 static int jvmObjectMonitorTryLock(pthread_t thisThread) {
     pthread_t own = omonitor->_owner;
     if (own != NO_THREAD) return 0; /* Already grabbed */
     if (o_thread_cmpxchg(thisThread, &omonitor->_owner,
                     NO_THREAD) == NO_THREAD) {
+        assert(omonitor->_owner == thisThread, "invariant");
         /* Got it */
         return 1;
     }
@@ -411,12 +718,12 @@ static int jvmObjectMonitorTryLock(pthread_t thisThread) {
     return -1;
 }
 
-/* 
+/*
  * Try to spin before trying to grab the lock.  Lotta try in that code.
  * See ObjectMonitor::TrySpin().
  */
-static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
-    int ctr = Knob_FixedSpin;
+int jvmObjectMonitorTrySpin(pthread_t thisThread) {
+    int ctr = Knob_FixedSpin;   // is 0 in this code
     if (ctr != 0) {
         while (--ctr >= 0) {
             if (jvmObjectMonitorTryLock(thisThread) > 0) return 1;
@@ -425,12 +732,14 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
         return 0;
     }
 
-    for (ctr = Knob_PreSpin + 1; --ctr >= 0;) {
-        if (jvmObjectMonitorTryLock(thisThread) > 0) {
-            int x = omonitor->_SpinDuration;
-            if (x < Knob_SpinLimit) {
-                if (x < Knob_Poverty) x = Knob_Poverty;
-                omonitor->_SpinDuration = x + Knob_BonusB;
+    // try to cmpxchg thisThread into omonitor->_owner up to 10 times.
+    // increase omonitor->_SpinDuration for each successful TryLock insertion.
+    for (ctr = Knob_PreSpin + 1; --ctr >= 0;) {             // Knob_PreSpin = 10
+        if (jvmObjectMonitorTryLock(thisThread) > 0) {  // TryLock returns > 0 if thisThread wins
+            int x = omonitor->_SpinDuration;                // initially 0
+            if (x < Knob_SpinLimit) {                       // Knob_SpinLimit = 5000
+                if (x < Knob_Poverty) x = Knob_Poverty;     // Knob_Poverty = 1000
+                omonitor->_SpinDuration = x + Knob_BonusB;  // Knob_BonusB = 100; first time it will be 1100
             }
             return 1;
         }
@@ -441,12 +750,12 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
      * Admission control - verify preconditions for spinning
      */
     ctr = omonitor->_SpinDuration;
-    if (ctr < Knob_SpinBase) ctr = Knob_SpinBase;
+    if (ctr < Knob_SpinBase) ctr = Knob_SpinBase;           // Knob_SpinBase == 0
     if (ctr <= 0) return 0;
-    
-    if (Knob_SuccRestrict && omonitor->_succ != NO_THREAD) return 0;
 
-    int MaxSpin = Knob_MaxSpinners;
+    if (Knob_SuccRestrict && omonitor->_succ != NO_THREAD) return 0;    // Knob_SuccRestrict == 0
+
+    int MaxSpin = Knob_MaxSpinners;     // Knob_MaxSpinners == -1
     if (MaxSpin >= 0) {
         if (omonitor->_Spinner > MaxSpin) {
             fprintf(stderr, "Spin abort -- too many spinners\n");
@@ -459,9 +768,9 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
     /* Time to start spinning... */
     int hits    = 0;
     int msk     = 0;
-    int caspty  = Knob_CASPenalty;
-    int oxpty   = Knob_OXPenalty;
-    int sss     = Knob_SpinSetSucc;
+    int caspty  = Knob_CASPenalty;          // -1
+    int oxpty   = Knob_OXPenalty;           // -1
+    int sss     = Knob_SpinSetSucc;         // 1
     if (sss && omonitor->_succ == NO_THREAD) omonitor->_succ = thisThread;
     pthread_t prv = NO_THREAD;
 
@@ -479,10 +788,10 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
             if (doSafepointSynchronizeCallBack()) {
                 goto Abort;
             }
-            if (Knob_UsePause & 1) SpinPause();
+            if (Knob_UsePause & 1) SpinPause(); // Knob_UsePause == 1, so always
         }
 
-        if (Knob_UsePause & 2) SpinPause();
+        if (Knob_UsePause & 2) SpinPause(); // Knob_UsePause == 1, so never
 
         /* Exponential backoff */
         if (ctr & msk) continue;
@@ -493,16 +802,16 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
 
         /* Probe owner.  Haven't they suffered enough? */
         pthread_t ox = omonitor->_owner;
-        if (ox == NO_THREAD) {
+        if (ox == NO_THREAD) {      // if monitor has no owner
             ox = o_thread_cmpxchg(thisThread, &omonitor->_owner, NO_THREAD);
             if (ox == NO_THREAD) {
                 /* The CAS succeeded, so the thread has ownership.
                  * Do some bookkeeping to exit spin state.
                  */
-                if (sss && (omonitor->_succ == thisThread)) {
+                if (sss && (omonitor->_succ == thisThread)) {   // sss == 1 (Knob_SpinSetSucc)
                     omonitor->_succ = NO_THREAD;
                 }
-                if (MaxSpin > 0) Adjust(&omonitor->_Spinner, -1);
+                if (MaxSpin > 0) Adjust(&omonitor->_Spinner, -1);   // MaxSpin == -1, so never this
 
                 /* Increase SpinDuration */
                 int x = omonitor->_SpinDuration;
@@ -514,9 +823,9 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
             }
 
             /* The CAS failed. */
-            prv = ox;
-            if (caspty == -2) break;
-            if (caspty == -1) goto Abort;
+            prv = ox;       // ox is the current monitor owner.
+            if (caspty == -2) break;        // caspty == Knob_CASPenalty == -1
+            if (caspty == -1) goto Abort;   // caspty == Knob_CASPenalty == -1, so Abort
             ctr -= caspty;
             continue;
         }
@@ -525,7 +834,7 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
         if (ox != prv && prv != NO_THREAD) {
             if (oxpty == -2) break;
             if (oxpty == -1) goto Abort;
-            ctr -= oxpty;
+            ctr -= oxpty;       // oxpty == Knob_OXPenalty, so this increases ctr?
         }
         prv = ox;
 
@@ -544,18 +853,17 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
         }
     }
  Abort:
-    if (MaxSpin >= 0) Adjust(&omonitor->_Spinner, -1);
-    if (sss && omonitor->_succ == thisThread) {
+    if (MaxSpin >= 0) Adjust(&omonitor->_Spinner, -1);  // MaxSpin == -1, so never this
+    if (sss && omonitor->_succ == thisThread) { // sss == 1
         omonitor->_succ = NO_THREAD;
         // Invariant: after setting succ=null a contending thread
         // must recheck-retry _owner before parking.  This usually happens
         // in the normal usage of TrySpin(), but it's safest
         // to make TrySpin() as foolproof as possible.
-        FULL_MEM_BARRIER;
+        OrderAccess_fence();
         if (jvmObjectMonitorTryLock(thisThread) > 0) return 1;
     }
     return 0;
-    
 }
 
 /* This is called by the jvmObjectMonitorEnter() call to handle cases where
@@ -563,30 +871,66 @@ static int jvmObjectMonitorTrySpin(pthread_t thisThread) {
  * will try to lock, try to spin, and if that gets to be too much, park
  * itself until told to wake up by another thread leaving the ObjectMonitor.
  */
-void jvmObjectMonitorEnterI(pthread_t thisThread) {
+void jvmObjectMonitorEnterI(pthread_t thisThread, const unsigned long threadnum) {
+
+    struct ParkEvent * Self_ParkEvent = &park_events[threadnum];
+
     /* Try the lock ... again.*/
     if (jvmObjectMonitorTryLock(thisThread) > 0) {
+        assert(omonitor->_succ != thisThread, "invariant");
+        assert(omonitor->_owner == thisThread, "invariant");
+        assert(omonitor->_Responsible != thisThread, "invariant");
         return;
     }
 
     /* Try one round of spinning before enqueing self... */
     if (jvmObjectMonitorTrySpin(thisThread) > 0) {
+        assert(omonitor->_owner == thisThread, "invariant");
+        assert(omonitor->_succ != thisThread, "invariant");
+        assert(omonitor->_Responsible != thisThread, "invariant");
         return;
     }
 
     /* The Spin failed -- enqueue and park this thread. */
-    struct ObjectWaiter *node = initializeObjectWaiter(thisThread);
-    node->_state = TS_CXQ;
+    assert(omonitor->_succ != thisThread, "invariant");
+    assert(omonitor->_owner != thisThread, "invariant");
+    assert(omonitor->_Responsible != thisThread, "invariant");
+
+#ifdef MALLOC_OBJECTWAITER
+    struct ObjectWaiter *node = initializeObjectWaiter(thisThread, Self_ParkEvent);
+    node->_prev = (struct ObjectWaiter *) 0xBAD;
+    node->TState = TS_CXQ;
+#else
+    // ObjectWaiter is a stack object.
+    struct ObjectWaiter node_ __attribute__((aligned(64))) = {
+        ._next = NULL,
+        ._prev = (struct ObjectWaiter *) 0xBAD,
+        ._thread = thisThread,
+        .TState = TS_CXQ,
+        ._event = Self_ParkEvent,
+    };
+    parkevent_init(Self_ParkEvent);
+    struct ObjectWaiter * node = &node_;
+#endif
+
+    // push self onto _cxq
     struct ObjectWaiter *nxt;
     for (;;) {
         node->_next = nxt = omonitor->_cxq;
         if (o_ow_cmpxchg(node, &omonitor->_cxq, nxt) == nxt) break;
+
+        // if here, CAS failed because _cxq changed
+
         if (jvmObjectMonitorTryLock(thisThread) > 0) {
+            assert(omonitor->_succ != thisThread, "invariant");
+            assert(omonitor->_owner == thisThread, "invariant");
+            assert(omonitor->_Responsible != thisThread, "invariant");
             cleanupObjectWaiter(node);
             return;
         }
     }
 
+    // insert thisThread as _Responsible if no thread currently is.
     if ((nxt == NULL) && (omonitor->_EntryList == NULL)) {
         o_thread_cmpxchg(thisThread, &omonitor->_Responsible, NO_THREAD);
     }
@@ -595,43 +939,56 @@ void jvmObjectMonitorEnterI(pthread_t thisThread) {
     int recheckInterval = 1;
     for (;;) {
         if (jvmObjectMonitorTryLock(thisThread) > 0) break;
+        assert(omonitor->_owner != thisThread, "invariant");
+
+        // park self
         if (omonitor->_Responsible == thisThread) {
-            parkObjectWaiterTimed(node, recheckInterval);
+            // the responsible thread uses the timed parking
+            parkTimed(Self_ParkEvent, (long) recheckInterval);
             recheckInterval *= 8;
             if (recheckInterval > MAX_RECHECK_INTERVAL) {
                 recheckInterval = MAX_RECHECK_INTERVAL;
             }
         } else {
-            parkObjectWaiter(node);
+            // other threads use the indefinite parking
+            park(Self_ParkEvent);
         }
 
+        // if here, thisThread has awakened
         if (jvmObjectMonitorTryLock(thisThread) > 0) break;
         ++nWakeups;
-        if ((Knob_SpinAfterFutile & 1) &&
+        if ((Knob_SpinAfterFutile & 1) &&                   // is 1
                 (jvmObjectMonitorTrySpin(thisThread) > 0)) break;
-        if ((Knob_ResetEvent & 1) && (node->_Event != 0)) {
-            node->_Event = 0;
-            FULL_MEM_BARRIER;
+        if ((Knob_ResetEvent & 1) && (Self_ParkEvent->_Event != 0)) { // never
+            Self_ParkEvent->_Event = 0;       // XXX: Self->_ParkEvent->reset()
+            OrderAccess_fence();
         }
         if (omonitor->_succ == thisThread) omonitor->_succ = NO_THREAD;
-        FULL_MEM_BARRIER;
+        OrderAccess_fence();  // after clearing _succ, a thread must retry _owner before parking.
     }
 
     /* Egress: Self has acquired the lock.  Note that we unlink
      * the node from the queue, then destroys it (since we own
      * the ObjectMonitor -- we don't need that ObjectWaiter anymore...
      */
-    UnlinkAfterAcquire(thisThread, node);
-    cleanupObjectWaiter(node);
-    if (omonitor->_succ == thisThread) omonitor->_succ = NO_THREAD;
+
+    assert(omonitor->_owner == thisThread, "invariant");
+
+    UnlinkAfterAcquire(thisThread, node);   // this unlink is supposed to update EntryList
+    if (omonitor->_succ == thisThread) { omonitor->_succ = NO_THREAD; }
+
+    assert(omonitor->_succ != thisThread, "invariant");
+
     if (omonitor->_Responsible == thisThread) {
         omonitor->_Responsible = NO_THREAD;
-        FULL_MEM_BARRIER;
+        OrderAccess_fence();
     }
+
+    cleanupObjectWaiter(node);
 }
 
-int jvmObjectMonitorExitSuspendEquivalent(pthread_t thisThread) {
-    return 1;
+static int jvmObjectMonitorExitSuspendEquivalent(pthread_t thisThread) {
+    return 0;
 }
 
 /* This represents ObjectMonitor::enter() over in the JVM.  It basically
@@ -642,46 +999,71 @@ int jvmObjectMonitorExitSuspendEquivalent(pthread_t thisThread) {
  * and blocks until woken up. So the only way out of here is to actually
  * get ownership of the ObjectMonitor itself.
  */
-static unsigned long jvmObjectMonitorEnter(pthread_t thisThread) {
+unsigned long jvmObjectMonitorEnter(pthread_t thisThread, const unsigned long threadnum) {
     pthread_t cur = o_thread_cmpxchg(thisThread, &omonitor->_owner, NO_THREAD);
     if (cur == NO_THREAD) {
-        return 1;
-    }
-    if (Knob_SpinEarly && jvmObjectMonitorTrySpin(thisThread) > 0) {
+        assert(omonitor->_owner == thisThread, "invariant");
         return 1;
     }
 
+    // the "Try one round of spinning *before* enqueuing self and before
+    // going through the awkward and expensive state transitions."
+    if (Knob_SpinEarly && jvmObjectMonitorTrySpin(thisThread) > 0) {    // Knob_SpinEarly == 1
+        assert(omonitor->_owner == thisThread, "invariant");
+        return 1;
+    }
+
+    assert(omonitor->_owner != thisThread, "invariant");
+    assert(omonitor->_succ != thisThread, "invariant");
+    assert(omonitor->_count >= 0, "invariant");
+
     atomic_int_inc(&omonitor->_count);
+
     {
         for (;;) {
-            jvmObjectMonitorEnterI(thisThread);
-            break;
+            jvmObjectMonitorEnterI(thisThread, threadnum);
+            if (!jvmObjectMonitorExitSuspendEquivalent(thisThread)) break;
         }
     }
-    atomic_int_dec(&omonitor->_count);
-    return 1;
+
+    int depth = atomic_int_dec(&omonitor->_count);
+
+    assert(omonitor->_count >= 0, "invariant");
+    assert(omonitor->_owner == thisThread, "invariant");
+    assert(omonitor->_succ != thisThread, "invariant");
+
+    return depth;   // XXX: maybe this should be depth + 1?
 }
 
 /* Final cleanup code when a thread's releasing the ObjectMonitor.
  * It'll set the successor thread, release ownership of the ObjectMonitor,
  * then unpark the successor thread.
  */
-static void jvmObjectMonitorExitEpilog(pthread_t thisThread,
+void jvmObjectMonitorExitEpilog(pthread_t thisThread,
         struct ObjectWaiter* Wakee) {
-    omonitor->_succ = (Knob_SuccEnabled ? Wakee->_thread : NO_THREAD);
-    release_store_thread(&omonitor->_owner, NO_THREAD);
-    FULL_MEM_BARRIER;
-    unparkObjectWaiter(Wakee);
+    assert(omonitor->_owner == thisThread, "invariant");
+    omonitor->_succ = (Knob_SuccEnabled ? Wakee->_thread : NO_THREAD);  // Knob_SuccEnabled = 1
+    struct ParkEvent * Trigger = Wakee->_event;
+
+    Wakee = NULL;       // hygiene
+    release_store_thread(&omonitor->_owner, NO_THREAD); // drop the lock
+    OrderAccess_fence();  // ST _owner vs LD in unpark()
+
+    // In the original, unpark() is not called on Wakee because at this point
+    // the thread is no longer the monitor owner.  Instead, Trigger->unpark()
+    // is called using a retained pointer (Trigger) to its ParkEvent.
+    unpark(Trigger);
 }
 
 /* Called when the owning thread's ready to release the ObjectMonitor.
  * If there are no outstanding ObjectWaiters hanging in the queues, it'll
  * just return once it's cleaned up.  If there are, it'll do the
  * post-run maintenance on those queues and call jvmObjectMonitorExitEpilog()
- * to wake that next thread up. 
+ * to wake that next thread up.
  */
-static void jvmObjectMonitorExit(pthread_t thisThread) {
-    if (thisThread == omonitor->_owner) {
+void jvmObjectMonitorExit(const pthread_t thisThread, const unsigned long threadnum) {
+
+    if (thisThread != omonitor->_owner) {
         omonitor->_owner = thisThread;
         /* Removed code having to do with recursions -- not tracking that. */
     }
@@ -689,18 +1071,27 @@ static void jvmObjectMonitorExit(pthread_t thisThread) {
     omonitor->_Responsible = NO_THREAD;
 
     for (;;) {
-        if (Knob_ExitPolicy == 0) {
-            release_store_thread(&omonitor->_owner, NO_THREAD);
+        assert(omonitor->_owner == thisThread);
+
+        if (Knob_ExitPolicy == 0) { // INFO: this is always true
+            release_store_thread(&omonitor->_owner, NO_THREAD);  // drop the lock
             storeload();
+
+            // See if we need to wake a successor
             if ((((intptr_t)omonitor->_EntryList | (intptr_t)omonitor->_cxq) == 0) ||
                     (omonitor->_succ != NO_THREAD)) {
                 return;
             }
 
+            // reacquire the lock so that entrylist or cxq can be manipulated.
             if (o_thread_cmpxchg(thisThread, &omonitor->_owner, NO_THREAD) != NO_THREAD) {
+                // if here, the monitor got owned by someone else just now.
                 return;
             }
+
+            // if here, then the monitor has been reacquired
         } else {
+            //assert(0);  // this basic block should never be called in this benchmark
             if ((((intptr_t)omonitor->_EntryList | (intptr_t)omonitor->_cxq) == 0) ||
                     (omonitor->_succ != NO_THREAD)) {
                 release_store_thread(&omonitor->_owner, NO_THREAD);
@@ -716,13 +1107,19 @@ static void jvmObjectMonitorExit(pthread_t thisThread) {
             }
         }
 
+        guarantee(omonitor->_owner == thisThread, "invariant");
+
         struct ObjectWaiter *w = NULL;
         int QMode = Knob_QMode;
+        (void) QMode;
+
         /* Bunch of experimental stuff handling various QMode settings
          * removed for simplification -- never gets executed here...
          */
+
         w = omonitor->_EntryList;
         if (w != NULL) {
+            assert(w->TState == TS_ENTER, "invariant");
             jvmObjectMonitorExitEpilog(thisThread, w);
             return;
         }
@@ -731,34 +1128,216 @@ static void jvmObjectMonitorExit(pthread_t thisThread) {
         if (w == NULL) continue;
 
         for (;;) {
+            assert(w != NULL, "Invariant");
+            // u = *omonitor->_cxq; if *omonitor->_cxq == w, insert NULL.
             struct ObjectWaiter *u = o_ow_cmpxchg(NULL, &omonitor->_cxq, w);
             if (u == w) break;
             w = u;
         }
+
+        assert(w != NULL, "invariant");
+        assert(omonitor->_EntryList == NULL, "invariant");
 
         /* Was a check here for QMode == 1, but what follows is QMode == 0 */
         omonitor->_EntryList = w;
         struct ObjectWaiter *q = NULL;
         struct ObjectWaiter *p;
         for (p = w; p != NULL; p = p->_next) {
-            p->_state = TS_ENTER;
+            guarantee(p->TState == TS_CXQ, "Invariant");
+            p->TState = TS_ENTER;
             p->_prev = q;
             q = p;
         }
 
         if (omonitor->_succ != NO_THREAD) continue;
+
+        // if here, there was no successor.
         w = omonitor->_EntryList;
         if (w != NULL) {
+            guarantee(w->TState == TS_ENTER, "invariant");
             jvmObjectMonitorExitEpilog(thisThread, w);
             return;
         }
     }
 }
 
-/* Called once to initialize the ObjectMonitor. */
-static void jvm_init_locks(uint64_t *lock, unsigned long cores) {
-    // Initialize the ObjectMonitor
-    omonitor = (struct ObjectMonitor*)malloc(sizeof(struct ObjectMonitor));
+// -------------------------------
+
+/* Called once per measurement to initialize the ObjectMonitor and ParkEvents. */
+void jvm_init_locks(uint64_t *lock, unsigned long num_threads) {
+
+//#define PRINT_STRUCT_LAYOUTS
+#ifdef PRINT_STRUCT_LAYOUTS
+
+    printf("\n");
+
+#define OOSO_(f, g) \
+    printf("%30s :  offsetof %-3zu  sizeof %-3zu\n", \
+        stringify(g), \
+        offsetof(typeof(*(f)), g), \
+        sizeof(f->g))
+
+#define PE_OOSO(g) \
+    OOSO_(((struct ParkEvent *)0), g)
+
+    printf("ParkEvent:\n");
+    PE_OOSO(CachePad);
+    PE_OOSO(_Event);
+    PE_OOSO(_nParked);
+    PE_OOSO(_mutex);
+
+    PE_OOSO(_mutex[0].__data.__lock);
+    PE_OOSO(_mutex[0].__data.__count);
+    PE_OOSO(_mutex[0].__data.__owner);
+    PE_OOSO(_mutex[0].__data.__nusers);
+    PE_OOSO(_mutex[0].__data.__kind);
+    PE_OOSO(_mutex[0].__data.__spins);
+#ifdef __x86_64__
+    PE_OOSO(_mutex[0].__data.__elision);
+#endif
+    PE_OOSO(_mutex[0].__data.__list);
+    PE_OOSO(_mutex[0].__data);
+    PE_OOSO(_mutex[0].__size);
+    PE_OOSO(_mutex[0].__align);
+
+    PE_OOSO(_cond);
+
+    PE_OOSO(_cond[0].__data.__wseq);
+    PE_OOSO(_cond[0].__data.__g1_start);
+    PE_OOSO(_cond[0].__data.__g_refs);
+    PE_OOSO(_cond[0].__data.__g_size);
+    PE_OOSO(_cond[0].__data.__g1_orig_size);
+    PE_OOSO(_cond[0].__data.__wrefs);
+    PE_OOSO(_cond[0].__data.__g_signals);
+    PE_OOSO(_cond[0].__size);
+    PE_OOSO(_cond[0].__align);
+
+    PE_OOSO(PostPad);
+    PE_OOSO(_Assoc);
+    PE_OOSO(FreeNext);
+    PE_OOSO(AssociatedWith);
+    PE_OOSO(ListNext);
+    PE_OOSO(OnList);
+    PE_OOSO(TState);
+    PE_OOSO(Notified);
+    printf("total = %zu\n", sizeof(struct ParkEvent));
+    printf("\n");
+
+
+#define OM_OOSO(g) \
+    OOSO_(((struct ObjectMonitor *)0), g)
+
+    printf("ObjectMonitor:\n");
+    OM_OOSO(_owner);
+    OM_OOSO(_EntryList);
+    OM_OOSO(_cxq);
+    OM_OOSO(_cxq);
+    OM_OOSO(_succ);
+    OM_OOSO(_Responsible);
+    OM_OOSO(_Spinner);
+    OM_OOSO(_SpinDuration);
+    OM_OOSO(_count);
+    printf("total = %zu\n", sizeof(struct ObjectMonitor));
+    printf("\n");
+
+#define OW_OOSO(g) \
+    OOSO_(((struct ObjectWaiter *)0), g)
+
+    printf("ObjectWaiter:\n");
+    OW_OOSO(_next);
+    OW_OOSO(_prev);
+    OW_OOSO(_thread);
+    OW_OOSO(_notifier_tid);
+    OW_OOSO(_event);
+    OW_OOSO(_notified);
+    OW_OOSO(TState);
+    OW_OOSO(_Sorted);
+    OW_OOSO(_active);
+    printf("total = %zu\n", sizeof(struct ObjectWaiter));
+
+#endif
+
+    // free/make/remake an array of ParkEvent and initialize them.
+    // TODO: allocate park_events using the framework lock pointer. For now, malloc/free it.
+    if (park_events) {
+        for (size_t i = 0; i < park_events_length; i++) {
+            parkevent_destroy(&park_events[i]);
+        }
+        free(park_events);
+        park_events = NULL;
+        park_events_length = 0;
+    }
+
+    if (park_events == NULL) {
+        // ParkEvent are allocated on 256-byte alignment.
+        if (posix_memalign((void *) &park_events, 256, num_threads * sizeof(struct ParkEvent))) {
+            fprintf(stderr, "jvm_objectmonitor posix_memalign failed allocating park_events array\n");
+            exit(-1);
+        }
+
+        for (size_t i = 0; i < num_threads; i++) {
+            parkevent_init(&(park_events[i]));
+        }
+
+        park_events_length = num_threads;
+    }
+
+    if (!omonitor) {
+#ifdef USE_LOCK_POINTER
+        // first iter: set it to the lock pointer from test harness
+        omonitor = (struct ObjectMonitor *) lock;
+#else
+        // first iter: align the omonitor so that it fits into a 64 byte cache line.
+        if (posix_memalign((void *) &omonitor, 64, sizeof(struct ObjectMonitor))) {
+            fprintf(stderr, "jvm_objectmonitor posix_memalign failed allocating struct ObjectMonitor\n");
+            exit(-1);
+        }
+#endif
+    } else {
+        // second iter:  already have a pointer to the ObjectMonitor
+
+#ifdef USE_LOCK_POINTER
+        // on subsequent iterations, omonitor should already be set to the lock pointer.
+        if (omonitor != (struct ObjectMonitor *) lock) {
+            fprintf(stderr, "jvm_objectmonitor jvm_init_locks: omonitor != lock pointer!  omonitor = %p, expected %p\n", omonitor, lock);
+            exit(-1);
+        }
+#endif
+
+#ifdef MALLOC_OBJECTWAITER
+        // Free the ObjectWaiter lists, if any.  Not expecting there to be any.
+
+        struct ObjectWaiter *node = omonitor->_EntryList;
+        struct ObjectWaiter *next;
+        size_t num_freed = 0;
+
+        while (node) {
+            next = node->_next;
+            free(node);
+            node = next;
+            num_freed++;
+        }
+
+        if (num_freed) {
+            fprintf(stderr, "WARNING: jvm_init_locks had to free %zu nodes from omonitor->_EntryList\n", num_freed);
+        }
+
+        num_freed = 0;
+        node = omonitor->_cxq;
+        while (node) {
+            next = node->_next;
+            free(node);
+            node = next;
+            num_freed++;
+        }
+
+        if (num_freed) {
+            fprintf(stderr, "WARNING: jvm_init_locks had to free %zu nodes from omonitor->_cxq\n", num_freed);
+        }
+#endif
+    }
+
+    // initialize the object monitor
     omonitor->_owner = NO_THREAD;
     omonitor->_EntryList = NULL;
     omonitor->_cxq = NULL;
@@ -775,14 +1354,16 @@ static void jvm_init_locks(uint64_t *lock, unsigned long cores) {
 
 /* Lock interface back to the framework. */
 static inline unsigned long lock_acquire(uint64_t *lock,
-        unsigned long threadnum) {
-    return jvmObjectMonitorEnter(pthread_self());
+        const unsigned long threadnum) {
+    return jvmObjectMonitorEnter(pthread_self(), threadnum);
 }
 
 /* Unlock interface back to the framework. */
 static inline void lock_release(uint64_t *lock,
-        unsigned long threadnum) {
-    jvmObjectMonitorExit(pthread_self());
+        const unsigned long threadnum) {
+    jvmObjectMonitorExit(pthread_self(), threadnum);
 }
 
 #endif
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab : */

--- a/ext/linux/hybrid_spinlock_fastdequeue.h
+++ b/ext/linux/hybrid_spinlock_fastdequeue.h
@@ -18,7 +18,7 @@
 #undef initialize_lock
 #endif
 
-#define initialize_lock(lock, threads) mcs_init_locks(lock, threads)
+#define initialize_lock(lock, pinorder, threads) mcs_init_locks(lock, threads)
 
 #include "atomics.h"
 #include "lk_atomics.h"
@@ -52,7 +52,11 @@ struct mcs_spinlock *mcs_pool;
 
 void mcs_init_locks (uint64_t *lock, unsigned long cores)
 {
-	mcs_pool = (struct mcs_spinlock *) malloc(4 * cores * sizeof(struct mcs_spinlock));
+	size_t n = 4 * cores * sizeof(struct mcs_spinlock);
+	if (mcs_pool) { free(mcs_pool); }
+	mcs_pool = (struct mcs_spinlock *) malloc(n);
+	if (! mcs_pool) { fprintf(stderr, "malloc failed in " __FILE__ " %s\n", __func__); exit(-1); }
+	memset(mcs_pool, 0, n);
 }
 
 static inline unsigned ticket_depth (unsigned ticketval)
@@ -96,7 +100,7 @@ unsigned long hybrid_spinlock_slowpath(uint64_t *lock, unsigned long threadnum)
 	unsigned long depth = 0;
 	struct mcs_spinlock *prev, *next, *node;
 
-	u32 new, old, tail, val, ticketval;
+	u32 /* new, */ old, tail, val, ticketval;
 
 	int idx;
 
@@ -127,7 +131,7 @@ unsigned long hybrid_spinlock_slowpath(uint64_t *lock, unsigned long threadnum)
 
 	/* do ticket spin */
 #if defined(__aarch64__)
-	unsigned tmp, tmp2, tmp3;
+	unsigned /* tmp, */ tmp2, tmp3;
 #if _Q_DEQUEUE_THRESHOLD
 asm volatile (
 "	sevl\n"
@@ -218,7 +222,7 @@ unsigned long __attribute__((noinline)) lock_acquire (uint64_t *lock, unsigned l
 	unsigned enqueue;
 
 #if defined(__aarch64__)
-	unsigned tmp, tmp2, tmp3;
+	unsigned /* tmp, */ tmp2, tmp3;
 asm volatile (
 "1:	ldaxr	%w[ticket], %[lock]\n"
 "	add	%w[tmp2], %w[ticket], %w[ticket_inc]\n"
@@ -248,7 +252,7 @@ asm volatile (
 
 #if defined (__aarch64__)
 asm volatile (
-"	mov	%[enqueue], #1\n"
+"	mov	%w[enqueue], #1\n"
 "	sub	%w[tmp3], %w[ticket], %w[qthresh]\n"
 "	rev16	%w[tmp2], %w[tmp3]\n"
 "	eor	%w[tmp3], %w[tmp2], %w[tmp3]\n"
@@ -319,3 +323,5 @@ asm volatile (
 
 #endif
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab : */

--- a/ext/linux/hybrid_spinlock_old_fastdequeue.h
+++ b/ext/linux/hybrid_spinlock_old_fastdequeue.h
@@ -14,6 +14,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+//
+// NOTE: This file is currently unused
+//
+
+
 #ifdef initialize_lock
 #undef initialize_lock
 #endif
@@ -47,8 +52,13 @@ struct mcs_spinlock {
 
 struct mcs_spinlock *mcs_pool;
 
-void mcs_init_locks (uint64_t *lock, unsigned long cores) {
-	mcs_pool = (struct mcs_spinlock *) malloc(4 * cores * sizeof(struct mcs_spinlock));
+void mcs_init_locks (uint64_t *lock, unsigned long cores)
+{
+	size_t n = 4 * cores * sizeof(struct mcs_spinlock);
+	if (mcs_pool) { free(mcs_pool); }
+	mcs_pool = (struct mcs_spinlock *) malloc(n);
+	if (! mcs_pool) { fprintf(stderr, "malloc failed in " __FILE__ " %s\n", __func__); exit(-1); }
+	memset(mcs_pool, 0, n);
 }
 
 static inline __attribute((pure)) u32 encode_tail(int cpu, int idx)
@@ -282,3 +292,5 @@ asm volatile (
 
 #endif
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab : */

--- a/ext/linux/include/lk_cmpxchg.h
+++ b/ext/linux/include/lk_cmpxchg.h
@@ -222,22 +222,21 @@ __CMPXCHG_CASE( ,  ,  mb_8, dmb ish,  , l, "memory")
 #undef __CMPXCHG_CASE
 
 #define __LSE_CMPXCHG_CASE(w, sz, name, mb, cl...)                      \
-static inline unsigned long __cmpxchg_case_##name(volatile void *ptr,   \
-                                                  unsigned long old,    \
-                                                  unsigned long new)    \
+static inline unsigned long __lse__cmpxchg_case_##name(volatile void *ptr,   \
+                          unsigned long old,                            \
+                          unsigned long new)                            \
 {                                                                       \
-    register unsigned long x0 asm ("x0") = (unsigned long)ptr;          \
-    register unsigned long x1 asm ("x1") = old;                         \
-    register unsigned long x2 asm ("x2") = new;                         \
-    unsigned long tmp;                                                  \
+    register unsigned long x0 = (unsigned long)ptr;                     \
+    register unsigned long x1 = old;                                    \
+    register unsigned long x2 = new;                                    \
+    register unsigned long xtemp;                                       \
                                                                         \
     asm volatile(                                                       \
     /* LSE atomics */                                                   \
-    "   mov %" #w "[tmp], %" #w "[old]\n"                               \
-    "   cas" #mb #sz "\t%" #w "[tmp], %" #w "[new], %[v]\n"             \
-    "   mov %" #w "[ret], %" #w "[tmp]"                                 \
-    : [ret] "+r" (x0), [v] "+Q" (*(unsigned long *)ptr),                \
-      [tmp] "=&r" (tmp)                                                 \
+    "   mov %" #w "[temp], %" #w "[old]\n"                              \
+    "   cas" #mb #sz "\t%" #w "[temp], %" #w "[new], %[v]\n"            \
+    "   mov %" #w "[ret], %" #w "[temp]"                                \
+    : [ret] "+r" (x0), [v] "+Q" (*(unsigned long *)ptr) , [temp] "=&r" (xtemp) \
     : [old] "r" (x1), [new] "r" (x2)                                    \
     : cl);                                                              \
                                                                         \
@@ -287,13 +286,13 @@ static inline unsigned long __cmpxchg##sfx(volatile void *ptr,          \
 {                                                                       \
     switch (size) {                                                     \
     case 1:                                                             \
-        return __cmpxchg_case##sfx##_1(ptr, (u8)old, new);              \
+        return __lse__cmpxchg_case##sfx##_1(ptr, (u8)old, new);         \
     case 2:                                                             \
-        return __cmpxchg_case##sfx##_2(ptr, (u16)old, new);             \
+        return __lse__cmpxchg_case##sfx##_2(ptr, (u16)old, new);        \
     case 4:                                                             \
-        return __cmpxchg_case##sfx##_4(ptr, old, new);                  \
+        return __lse__cmpxchg_case##sfx##_4(ptr, old, new);             \
     case 8:                                                             \
-        return __cmpxchg_case##sfx##_8(ptr, old, new);                  \
+        return __lse__cmpxchg_case##sfx##_8(ptr, old, new);             \
     }                                                                   \
                                                                         \
     unreachable();                                                      \
@@ -464,3 +463,5 @@ __XCHG_GEN(_mb)
 #endif /* __x86_64__ */
 
 #endif  /* __ASM_CMPXCHG_H */
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab : */

--- a/ext/linux/osq_lock.h
+++ b/ext/linux/osq_lock.h
@@ -8,22 +8,22 @@
  * Description:
  *
  *      This workload implements kernel 'optimistic spin queue' derived from mcs
- *      lock. Tunable unqueue_retry times and max_backoff_sleep duration have
+ *      lock.  Tunable unqueue_retry times and max_backoff_sleep duration have
  *      also been added to simulate need_resched() condition and unqueue current
  *      cpu node from spinning queue and put to sleep.
  *
  * Changes from Linux kernel osq_lock.c
  *
  *      The original DEFINE_PER_CPU_SHARED_ALIGNED(struct optimistic_spin_node,
- *      osq_node) was modified to 128 byte aligned optimistic_spin_node C array
- *      allocated in heap during osq_lock_init() in main thread. It was pointed
- *      by global_osq_nodepool_ptr pointer. The osq lock queue struct itself was
- *      declared as a global variable too, which would substitute upper level
- *      mutex lock struct indicated by lock pointer. Therefore we don't need to
- *      get the lock pointer from lock_acquire() and lock_release() interface.
- *      The spinning node structure can be linearly located by osq_nodepool_ptr
- *      with threadnum/coreid as offset. The tail of osq_lock can be accessed
- *      by global_osq directly.
+ *      osq_node) is modified to global_osq_nodepool_ptr, a pointer to
+ *      cache-line aligned memory allocated externally in do_alloc(), which may
+ *      use a hugepage.  The osq lock queue struct itself is declared as a
+ *      global variable, which substitutes for the upper level mutex lock
+ *      struct indicated by lock pointer.  Therefore, we don't need to get the
+ *      lock pointer from lock_acquire() and lock_release() interface.  The
+ *      spinning node structure is located from global_osq_nodepool_ptr with
+ *      thread_num used as the index.  The tail of osq_lock is accessed by
+ *      global_osq directly.
  *
  *      We haven't changed the algorithm except adding unqueue_retry and max_
  *      sleep_us as optional backoff sleep to mimic kernel rescheduling events.
@@ -44,66 +44,159 @@
  *      Kernel arm64 cmpxchg.h supports both LLSC (load-link/store-conditional)
  *      and LSE (Armv8.1 large system extension) via dynamic binary patching.
  *      If CONFIG_AS_LSE and CONFIG_ARM64_LSE_ATOMICS have been enabled, kernel
- *      will use Armv8.1 new atomic instructions CAS to implement the compare
- *      and swap function. This inline function has 3 instructions mov/cas/mov,
- *      which will be overwritten during system boot up if the CPU doesn't
- *      support Armv8.1 LSE. The 3 new instructions are bl/nop/nop. The branch
- *      and link instruction will redirect program flow to Armv8.0 LLSC function
- *      without saving any of the caller's local registers. These registers are
+ *      will use the Armv8.1 CAS instruction to implement the compare and swap
+ *      function. This inline function has 3 instructions mov/cas/mov, which
+ *      will be overwritten during system boot up if the CPU doesn't support
+ *      Armv8.1 LSE. The 3 new instructions are bl/nop/nop. The branch and link
+ *      instruction will redirect program flow to Armv8.0 LLSC function without
+ *      saving any of the caller's local registers. These registers are
  *      guaranteed to be safe because LLSC function in atomic_ll_sc.o only uses
  *      x16/x17 and LSE caller doesn't use x16/x17.
  *
- *      Since lockhammer doesn't have runtime cpu detection, whether to use LLSC
- *      or LSE is manually defined in lockhammer Makefile. Therefore our new
- *      cmpxchg is also statically defined without branch and link or binary
- *      patching. LLSC and LSE cmpxchg will share the same interface but use
- *      different assembly codes and functions.
+ *      Since lockhammer doesn't have runtime cpu detection, to use LSE is
+ *      selected by passing USE_LSE=1 to the lockhammer Makefile.  Therefore
+ *      our new cmpxchg is also statically defined without branch and link or
+ *      binary patching. LLSC and LSE cmpxchg will share the same interface but
+ *      use different assembly code and intrinsic function calls.
  *
  * Workings:
  *
  *      osq_lock works similar to mcs spinlock except the optional unqueue path.
  *      Linux kernel qspinlock is slightly different than original mcs spinlock.
  *
- * Tuning Parameters
+ * Tuning Parameters:
  *
- *      Optional unqueue and backoff sleep feature like kernel mutex
+ *      osq_lock tuning parameters are optional.  They are specified on the
+ *      lockhammer command line after lockhammer's own flags and separated from
+ *      them by "--".  These osq_lock_flags apply to all iterations.
  *
- *      [-- [-u unqueue_retry]]: how many spin retries before jumping to unqueue
- *                               path and stop spinning.
+ *          lh_osq_lock  lockhammer_flags ...  --  osq_lock_flags ...
  *
- *      [-- [-s max_sleep_us]]: how long to sleep after unqueue from osq before
- *                              another osq_lock() acquisition attempt. This
- *                              parameter only defines the maximum sleep time in
- *                              microseconds, each thread will sleep for random
- *                              time less than this max_sleep_us. The actual
- *                              sleep time is predetermined during main thread
- *                              initialization phase with uniform distribution
- *                              random function rand().
  *
+ *      -u unqueue_retries                 Default: 2000000000 (2 billion)
+ *          Max spin retries before going to unqueue path.
+ *
+ *      -S cpu:backoff_wait_us
+ *          For the thread that runs on the specified cpu, wait for the
+ *          specified backoff_wait_us microseconds on osq_lock unqueue.
+ *          Overrides the value computed from -s max_backoff_wait_us * rand().
+ *
+ *      -s max_backoff_wait_us             Default: 0 us
+ *          For each thread on cpus that do not have -S cpu:backoff_wait_us
+ *          specified, the maximum backoff wait time in microseconds after an
+ *          unqueue before another osq_lock() acquisition attempt.  The actual
+ *          wait time is determined at init by choosing a random duration on
+ *          the interval [0, max_backoff_wait_us), and waits for that same
+ *          amount of time after each unqueue.  The wait is now implemented
+ *          using the blackhole function to avoid making a nanosleep syscall.
+ *
+ *      -R random_seed                     Default: 0 (use seconds since epoch)
+ *          Specify a random seed to use.  If not specified or if 0 is
+ *          specified, then the number of seconds since the epoch is used.
+ *          Affects the computed backoff_wait_us = rand() * max_backoff_wait_us.
+ *
+ *      -D cpu:delay0[,delay1[,delay2[,delay3]]]
+ *          For the thread that runs on the specified cpu, at the callsite
+ *          corresponding to the delay parameter, calls CPU_RELAX() the delay
+ *          number of times.  See comment at the bottom of this file for a
+ *          function callstack outline showing the locations of the 4
+ *          callsites.  Note: CPU_RELAX is re-implemented in osq_lock.h, so
+ *          cpu_relax from ext/linux/include/lk_atomics.h is not being used.
+ *          This flag needs CPU_RELAX_PARAMETERIZED_DELAY to be enabled below.
  */
 
 #ifndef __LINUX_OSQ_LOCK_H
 #define __LINUX_OSQ_LOCK_H
 
+
+//#define OSQ_LOCK_COUNT_LOOPS           // enable to count per-cpu loop iterations; also edit src/report.c to enable
+//#define CPU_RELAX_PARAMETERIZED_DELAY  // enable osq_lock_cpu_relax() that can repeatedly call cpu_relax()
+
+
 /* redefine initialize_lock and parse_test_args with local functions */
 #ifdef initialize_lock
 #undef initialize_lock
 #endif
+#define initialize_lock(p_lock, pinorder, num_threads) osq_lock_init(p_lock, pinorder, num_threads)
 
 #ifdef parse_test_args
 #undef parse_test_args
 #endif
-
-#define initialize_lock(lock, threads) osq_lock_init(lock, threads)
 #define parse_test_args(args, argc, argv) osq_parse_args(args, argc, argv)
 
+
+// these are also used in lk_atomics.h
+#ifdef CPU_RELAX_PARAMETERIZED_DELAY
+#define CPU_RELAX(D) osq_lock_cpu_relax(D)
+#else
+#define CPU_RELAX(D) cpu_relax()
+#endif
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+#define INCREMENT_COUNTER(x) ((*(x))++)
+#else
+#define INCREMENT_COUNTER(x)
+#endif
+
+
+#include <inttypes.h>
 #include <stdbool.h>
 #include "atomics.h"
+#include "cpu_relax.h"
 #include "lk_atomics.h"
 #include "lk_cmpxchg.h"
 #include "lk_barrier.h"
 
 #define ATOMIC_INIT(i)    { (i) }
+
+#ifndef LONG_LONG_MAX
+#define LONG_LONG_MAX   LLONG_MAX
+#endif
+
+
+// thread_to_sleep_time_us[] and thread_to_relax[] are remade each time
+// osq_lock_init() is run because different pinorders may place a thread on
+// different CPUs.
+
+#define OSQ_DEFAULT_SLEEP_TIME -1
+#define OSQ_DEFAULT_RELAX_ITER 1
+
+
+// For thread i, thread_to_sleep_time_us[i] contains the duration in usecs
+// between attempts at aquiring the lock after unqueue_retries times.
+long * thread_to_sleep_time_us;
+
+
+// thread_to_relax[i] has the number of cpu_relax() iterations to run for the thread
+// in osq_lock_cpu_relax() at the four callsites:
+//     [0] = osq_lock   - fast-path loop
+//     [1] = osq_lock   - unqueue step A loop
+//     [2] = osq_lock   - unqueue step B osq_wait_next loop
+//     [3] = osq_unlock - osq_wait_next loop
+long (*thread_to_relax)[4];
+
+
+// osq_per_cpu_parameters is filled by osq_parse_args() to record each
+// per-cpu -S and/or -D parameter.  This is done only once.
+struct {
+    size_t num_entries;
+    struct {
+        long cpu;
+        long sleep_time_us; // for thread_to_sleep_time_us[]
+        long iters[4];      // for thread_to_relax
+    } * params;
+} osq_per_cpu_parameters = {
+    .num_entries = 0,
+    .params = NULL,
+};
+
+
+static inline void osq_lock_cpu_relax (long relax) {
+    while (relax--) {
+        __cpu_relax();
+    }
+}
+
 
 /*
  * An MCS like lock especially tailored for optimistic spinning for sleeping
@@ -113,18 +206,24 @@
  * called from interrupt context and we have preemption disabled while
  * spinning.
  *
- * Using 128 bytes alignment to eliminate false sharing for various Armv8 core
- * cache line size
+ * The important elements are in the first 64 bytes of each optimistic_spin_node.
+ * This code previously set SPIN_NODE_ALIGNMENT to 128 to avoid false sharing
+ * on CPUs that had 128-byte cache line lengths, but 64 bytes is the common cache
+ * line length now.  This should match the value from get_ctr_erg_bytes().
+ *
+ * cpu_to_node() returns a pointer to each optimistic_spin_node element from
+ * the linear virtual address for the requested CPU.
  */
 
-#define SPIN_NODE_ALIGNMENT 128UL
-#define SPIN_TAIL_ALIGNMENT 128UL
+#define SPIN_NODE_ALIGNMENT 64UL
 
 struct optimistic_spin_node {
-    struct optimistic_spin_node *next, *prev;
-    int locked; /* 1 if lock acquired */
-    int cpu; /* encoded CPU # + 1 value */
-    int random_sleep; /* random sleep in us */
+    struct optimistic_spin_node *next;
+    struct optimistic_spin_node *prev;
+    long locked; /* 1 if lock acquired */
+    long cpu; /* encoded CPU # + 1 value */
+    unsigned long sleep_us; /* random sleep in us */
+    unsigned long sleep_blackhole;
 } __attribute__ ((aligned (SPIN_NODE_ALIGNMENT)));
 
 struct optimistic_spin_queue {
@@ -133,7 +232,7 @@ struct optimistic_spin_queue {
      * If the queue is empty, then it's set to OSQ_UNLOCKED_VAL.
      */
     atomic_t tail;
-} __attribute__ ((aligned (SPIN_TAIL_ALIGNMENT)));
+} __attribute__ ((aligned (SPIN_NODE_ALIGNMENT)));
 
 /* 0 means thread unlocked, 1~N represents each individual thread on core 1~N */
 #define OSQ_UNLOCKED_VAL (0)
@@ -156,24 +255,130 @@ struct optimistic_spin_queue {
 /* Init macro and function. */
 #define OSQ_LOCK_UNLOCKED { ATOMIC_INIT(OSQ_UNLOCKED_VAL) }
 
+
 /* Newly added global variables used by osq_lock algorithm */
 static long long unqueue_retry;
 static long long max_sleep_us;
 static struct optimistic_spin_queue global_osq;
 static struct optimistic_spin_node *global_osq_nodepool_ptr;
+static unsigned int srand_seed = 0;
+
+struct osq_lock_parameters_t {
+    unsigned long verbose;
+} osq_lock_parameters = {
+    .verbose = VERBOSE_NONE,
+};
+
+
+static void osq_parse_multicpu_parameter (char opt, char * optarg) {
+    char * pc;
+    char * saveptr;
+    size_t cpu;
+    const char * param_name;
+    size_t max_params;
+
+    switch (opt) {
+        case 'D':
+            param_name = "cpu_relax_iters";
+            max_params = 4;
+            break;
+        case 'S':
+            param_name = "sleep_time_us";
+            max_params = 1;
+            break;
+        default:
+            fprintf(stderr, "should never have gotten here\n");
+            exit(-1);
+            break;
+    }
+
+    // parse for the cpu number
+    pc = strtok_r(optarg, ":", &saveptr);
+
+    if (pc == NULL) {
+        fprintf(stderr, "expected -%c %s to be in the form cpu:%s\n", opt, optarg, param_name);
+        exit(-1);
+    }
+
+    cpu = strtol(pc, NULL, 0);
+
+    if (osq_lock_parameters.verbose)
+        printf("osq_parse_multicpu_parameter: parsing -%c %s for cpu = %zu\n", opt, optarg, cpu);
+
+
+    // find the entry for the cpu
+    int found = 0;
+    size_t i = 0;
+
+    for (; i < osq_per_cpu_parameters.num_entries; i++) {
+        if (osq_per_cpu_parameters.params[i].cpu == cpu) {
+            found = 1;
+            break;
+        }
+    }
+
+    if (!found) {
+        osq_per_cpu_parameters.params = reallocarray(
+            osq_per_cpu_parameters.params,
+            osq_per_cpu_parameters.num_entries + 1,
+            sizeof(osq_per_cpu_parameters.params[0])
+            );
+
+        if (osq_per_cpu_parameters.params == NULL) {
+            fprintf(stderr, "ERROR: reallocarray on osq_per_cpu_parameters.params failed\n");
+            exit(-1);
+        }
+
+        osq_per_cpu_parameters.params[i].iters[0] = 1;
+        osq_per_cpu_parameters.params[i].iters[1] = 1;
+        osq_per_cpu_parameters.params[i].iters[2] = 1;
+        osq_per_cpu_parameters.params[i].iters[3] = 1;
+        osq_per_cpu_parameters.params[i].sleep_time_us = -1;
+        osq_per_cpu_parameters.params[i].cpu = cpu;
+        osq_per_cpu_parameters.num_entries++;
+    }
+
+    // parse the arglist and update osq_per_cpu_parameters
+    for (size_t j = 0; j < max_params; j++) {
+        pc = strtok_r(NULL, ",", &saveptr);
+
+        if (pc == NULL) {
+            break;
+        }
+
+        long val = strtoul(pc, NULL, 0);
+
+        if (osq_lock_parameters.verbose)
+            printf("token = %s, val = %ld\n", pc, val);
+
+        switch (opt) {
+            case 'D':
+                osq_per_cpu_parameters.params[i].iters[j] = val;
+                break;
+            case 'S':
+                osq_per_cpu_parameters.params[i].sleep_time_us = val;
+                break;
+            default:
+                break;
+        }
+
+    }
+
+}
+
 
 /* Newly added additional tuning parameters for optional backoff sleep */
-static void osq_parse_args(test_args unused, int argc, char** argv) {
+static void osq_parse_args(test_args_t * t, int argc, char** argv) {
     int i = 0;
     char *endptr;
     unqueue_retry = DEFAULT_UNQUEUE_RETRY;
     max_sleep_us = MAX_BACKOFF_SLEEP_US;
 
     /* extended options retrieved after '--' operator */
-    while ((i = getopt(argc, argv, "u:s:")) != -1)
+    while ((i = getopt(argc, argv, "u:s:S:R:D:vh")) != -1)
     {
         switch (i) {
-          case 'u':
+          case 'u':         // maximum number of spin retries before unqueue path
             errno = 0;
             unqueue_retry = strtoll(optarg, &endptr, 10);
             if ((errno == ERANGE && (unqueue_retry == LONG_LONG_MAX))
@@ -184,7 +389,7 @@ static void osq_parse_args(test_args unused, int argc, char** argv) {
             }
             break;
 
-          case 's':
+          case 's':         // maximum interval between lock_acquire retries
             errno = 0;
             max_sleep_us = strtoll(optarg, &endptr, 10);
             if ((errno == ERANGE && (max_sleep_us == LONG_LONG_MAX))
@@ -198,16 +403,72 @@ static void osq_parse_args(test_args unused, int argc, char** argv) {
             }
             break;
 
-          default:
+          case 'D':         // per-cpu cpu_relax delay/iterations
+#ifdef CPU_RELAX_PARAMETERIZED_DELAY
+            osq_parse_multicpu_parameter('D', optarg);
+            break;
+#else
+            fprintf(stderr, "ERROR: lh_osq_lock was run with -D flag CPU_RELAX delays, but CPU_RELAX_PARAMETERIZED_DELAY is not enabled.\n");
+            exit(-1);
+            break;
+#endif
+
+          case 'S':         // per-cpu unqueue-to-acquire interval wait-time in microseconds
+            osq_parse_multicpu_parameter('S', optarg);
+            break;
+
+          case 'R':         // specify random seed for rand()
+            srand_seed = strtoumax(optarg, NULL, 0);
+            break;
+
+          case '?':
+          case ':':
+            if (i == '?')
+                printf("option flag %s is unknown\n\n", argv[optind-1]);
+            else if (i == ':')
+                printf("option flag %s is missing an argument\n\n", argv[optind-1]);
+          // fall-through
+          case 'h':
             fprintf(stderr,
                     "osq_lock additional options after --:\n"
                     "\t[-h print this msg]\n"
-                    "\t[-u max spin retries before unqueue, default 2 billions]\n"
-                    "\t[-s max unqueue sleep in microseconds, default 0]\n");
+                    "\t[-v copy verbosity from main]\n"
+                    "\t[-u max spin retries before unqueue, default 2 billion]\n"
+                    "\t[-s max unqueue sleep in microseconds, default is 0]\n"
+                    "\t[-R specify random seed]\n"
+#ifdef CPU_RELAX_PARAMETERIZED_DELAY
+                    "\t[-D i:0[,1[,2[,3]]]] for CPUi, cpu_relax() iterations at callsites 0/1/2/3\n"
+#endif
+                    "\t[-S i:usecs] for CPUi, use a unqueue-to-acquire interval\n");
             exit(2);
+          case 'v':
+            osq_lock_parameters.verbose = t->verbose;
+            break;
+          default:
+            fprintf(stderr, "osq_parse_args: shouldn't get here with i = %d\n", i);
+            exit(-1);
         }
     }
+
+    if (argc > optind) {
+        fprintf(stderr, "ERROR: (osq_parse_args) unknown argument %s, opterr=%d\n", argv[optind], opterr);
+        exit(-1);
+    }
+
+    if (osq_lock_parameters.verbose)
+        for (size_t i = 0; i < osq_per_cpu_parameters.num_entries; i++) {
+            printf("%zu: cpu=%ld, sleep_time_us=%ld, iters={%ld,%ld,%ld,%ld}\n",
+                i,
+                osq_per_cpu_parameters.params[i].cpu,
+                osq_per_cpu_parameters.params[i].sleep_time_us,
+                osq_per_cpu_parameters.params[i].iters[0],
+                osq_per_cpu_parameters.params[i].iters[1],
+                osq_per_cpu_parameters.params[i].iters[2],
+                osq_per_cpu_parameters.params[i].iters[3]);
+        }
+
 }
+
 
 /*
  * An MCS like lock especially tailored for optimistic spinning for sleeping
@@ -217,22 +478,91 @@ static void osq_parse_args(test_args unused, int argc, char** argv) {
  * called from interrupt context and we have preemption disabled while
  * spinning.
  */
-static inline void osq_lock_init(uint64_t *lock, unsigned long cores)
+static inline void osq_lock_init(unsigned long * p_test_lock, int * pinorder, unsigned long num_threads)
 {
-    /*
-     * Allocate optimistic_spin_node from the heap during main thread
-     * initialization. Each cpu core will have its own spinning node,
-     * aligned to 128 cache line.
-     */
-
-    size_t size = (cores + 1) * sizeof(struct optimistic_spin_node);
-
-    if (size % SPIN_NODE_ALIGNMENT) {
-	printf("size = %zu, is not a multiple of %zu\n", size, SPIN_NODE_ALIGNMENT);
-	exit(-1);
+    if (pinorder == NULL) {
+        fprintf(stderr, "ERROR: pinorder (cpu_list) should never be a null pointer!\n"); exit(-1);
     }
 
-    global_osq_nodepool_ptr = aligned_alloc(SPIN_NODE_ALIGNMENT, size);
+    if (thread_to_sleep_time_us)
+        free(thread_to_sleep_time_us);
+
+    thread_to_sleep_time_us = malloc(sizeof(thread_to_sleep_time_us[0]) * num_threads);
+    if (! thread_to_sleep_time_us) {
+        fprintf(stderr, "ERROR: thread_to_sleep_time_us malloc failure\n"); exit(-1);
+    }
+
+    if (thread_to_relax)
+        free(thread_to_relax);
+
+    thread_to_relax = malloc(sizeof(thread_to_relax[0]) * num_threads);
+    if (! thread_to_relax) {
+        fprintf(stderr, "ERROR: thread_to_relax malloc failure\n"); exit(-1);
+    }
+
+    for (size_t thread_number = 0; thread_number < num_threads; thread_number++) {
+
+        // initialize the per-thread parameters
+        thread_to_sleep_time_us[thread_number] = OSQ_DEFAULT_SLEEP_TIME;
+
+        for (size_t k = 0; k < 4; k++)
+            thread_to_relax[thread_number][k] = OSQ_DEFAULT_RELAX_ITER;
+
+        // update per-thread parameters for CPUs specified using the -S or -D flags
+        long cpu = pinorder[thread_number];
+
+        for (size_t i = 0; i < osq_per_cpu_parameters.num_entries; i++) {
+            if (osq_per_cpu_parameters.params[i].cpu == cpu) {
+                thread_to_sleep_time_us[thread_number] = osq_per_cpu_parameters.params[i].sleep_time_us;
+                for (size_t k = 0; k < 4; k++)
+                    thread_to_relax[thread_number][k] = osq_per_cpu_parameters.params[i].iters[k];
+            }
+        }
+
+    }
+
+    if (osq_lock_parameters.verbose >= VERBOSE_MORE) {
+        printf("lh_osq_lock: sizeof(struct optimistic_spin_node) = %zu\n",
+                sizeof(struct optimistic_spin_node));
+
+        for (size_t i = 0; i < num_threads; i++) {
+            long cpu = pinorder[i];
+            printf("lh_osq_lock: thread_to_sleep_time_us[thread %zu/cpu %ld]: %ld\n",
+                i, cpu, thread_to_sleep_time_us[i]);
+        }
+
+        for (size_t i = 0; i < num_threads; i++) {
+            long cpu = pinorder[i];
+            printf("lh_osq_lock: thread_to_relax[thread %zu/cpu %ld]: %ld %ld %ld %ld\n",
+                i, cpu, thread_to_relax[i][0], thread_to_relax[i][1],
+                thread_to_relax[i][2], thread_to_relax[i][3]);
+        }
+
+        printf("lh_osq_lock: max_sleep_us = %lld\n", max_sleep_us);
+    }
+
+    // Note:  osq_lock does not use the lock pointer passed into osq_lock_acquire()
+    // and osq_lock_release().  Instead, each thread gets an optimistic_spin_node
+    // from the array pointed to by global_osq_nodepool_ptr.  global_osq_nodepool_ptr
+    // is set to the memory allocated by the lockhammer harness through p_test_lock
+    // passed into this function.
+
+    size_t size = (num_threads + 1) * sizeof(struct optimistic_spin_node);
+
+    if (size % SPIN_NODE_ALIGNMENT) {
+        fprintf(stderr, "lh_osq_lock: ERROR: size = %zu, is not a multiple of %zu\n",
+                size, SPIN_NODE_ALIGNMENT);
+        exit(-1);
+    }
+
+    /*
+     * Each cpu core will have its own spinning node, aligned to SPIN_NODE_ALIGNMENT.
+     */
+
+    global_osq_nodepool_ptr = (struct optimistic_spin_node *) p_test_lock;
+
+    if (osq_lock_parameters.verbose >= VERBOSE_MORE)
+        printf("global_osq_nodepool_ptr = %p\n", global_osq_nodepool_ptr);
 
     if (global_osq_nodepool_ptr == NULL) exit(errno);
 
@@ -240,28 +570,67 @@ static inline void osq_lock_init(uint64_t *lock, unsigned long cores)
 
     /*
      * If osq spins more than unqueue_retry times, the spinning cpu may backoff
-     * and sleep for 1 ~ 10 microseconds (on average 5 microseconds). Each spinning
-     * thread uses a different backoff sleep time, and we can adjust the maximum
-     * sleep time by redefine MAX_BACKOFF_SLEEP_US or tuning via parameter '-s'
-     * By default, we disable this sleep (MAX_BACKOFF_SLEEP_US = 0)
-     *
-     * Note: Avoid assigning random_sleep a negative value, otherwise usleep would
-     * have a very large sleep time after implicit casting negative to uint32_t.
+     * and sleep for 1 ~ 10 microseconds (on average 5 microseconds).  Each
+     * spinning thread uses a randomly selected backoff sleep time.  The maximum
+     * sleep time given using the '-s' flag, but the default is to disable
+     * this sleep (MAX_BACKOFF_SLEEP_US = 0).
      */
-    srand(time(0));
-    for (int i = 0; i < cores; i++) {
-        if (max_sleep_us > 0)
-            (global_osq_nodepool_ptr + i)->random_sleep = rand() % max_sleep_us + 1;
+
+    if (max_sleep_us > 0) {
+        if (srand_seed == 0) {
+            srand_seed = time(0);   // seconds since the epoch
+        }
+
+        if (osq_lock_parameters.verbose >= VERBOSE_MORE)
+            printf("lh_osq_lock: srand_seed = %u\n", srand_seed);
+
+        srand(srand_seed);
+    }
+
+    for (size_t i = 0; i < num_threads; i++) {
+        char * random_string = "";
+        long sleep_time_us = thread_to_sleep_time_us[i];
+
+        if (sleep_time_us != OSQ_DEFAULT_SLEEP_TIME) {
+            global_osq_nodepool_ptr[i].sleep_us = sleep_time_us;
+        } else if (max_sleep_us > 0) {
+            global_osq_nodepool_ptr[i].sleep_us = rand() % max_sleep_us + 1;
+            random_string = " (randomly selected)";
+        } else {
+            global_osq_nodepool_ptr[i].sleep_us = 0;
+        }
+
+        if (osq_lock_parameters.verbose >= VERBOSE_MORE)
+            printf("lh_osq_lock: global_osq_nodepool_ptr[thread %zu].sleep_us = %lu%s\n",
+                    i, global_osq_nodepool_ptr[i].sleep_us, random_string);
     }
 
     /* Initialize global osq tail indicater to OSQ_UNLOCKED_VAL (0: unlocked) */
     atomic_set(&global_osq.tail, OSQ_UNLOCKED_VAL);
 }
 
+static void osq_lock_compute_blackhole_interval(unsigned long thread_number, double tickspns, unsigned long run_on_this_cpu, unsigned long numtries) {
+    unsigned long sleep_us = global_osq_nodepool_ptr[thread_number].sleep_us;
+    unsigned long sleep_blackhole = sleep_us ? calibrate_blackhole(tickspns * sleep_us * 1000, 0, TOKENS_MAX_HIGH, thread_number, numtries) : 0;
+
+    global_osq_nodepool_ptr[thread_number].sleep_blackhole = sleep_blackhole;
+
+    unsigned long cpu = run_on_this_cpu;
+
+    if (osq_lock_parameters.verbose >= VERBOSE_MORE)
+        printf("lh_osq_lock:  thread %lu cpu %lu: tickspns = %f, sleep_us = %lu, sleep_blackhole = %lu\n",
+                thread_number, cpu, tickspns, sleep_us, sleep_blackhole);
+}
+
+// ------------------- lock code starts here -------------------
+
+#if 0
+// this function is currently unused.
 static inline bool osq_is_locked(struct optimistic_spin_queue *lock)
 {
     return atomic_read(&lock->tail) != OSQ_UNLOCKED_VAL;
 }
+#endif
 
 /*
  * Value 0 represents "no CPU" or "unlocked", thus the encoded value will be
@@ -272,10 +641,13 @@ static inline int encode_cpu(int cpu_nr)
     return cpu_nr + 1;
 }
 
+#if 0
+// this function is currently unused.
 static inline int node_to_cpu(struct optimistic_spin_node *node)
 {
     return node->cpu - 1;
 }
+#endif
 
 /*
  * optimistic_spin_node for each cpu is stored linearly in main heap starting
@@ -291,22 +663,32 @@ static inline struct optimistic_spin_node * cpu_to_node(int encoded_cpu_val)
  * Get a stable @node->next pointer, either for unlock() or unqueue() purposes.
  * Can return NULL in case we were the last queued and we updated @lock instead.
  */
+#ifdef OSQ_LOCK_COUNT_LOOPS
 static inline struct optimistic_spin_node *
-osq_wait_next(struct optimistic_spin_queue *lock,
-          struct optimistic_spin_node *node,
-          struct optimistic_spin_node *prev,
-          unsigned long cpu_number)
+osq_wait_next(struct optimistic_spin_queue *lock,   // aka global_osq
+          struct optimistic_spin_node *node,        // aka us
+          struct optimistic_spin_node *prev,        // aka prev, the previous tail of the queue
+          unsigned long thread_number,              // our thread number
+          unsigned long * counter,                  // pointer to loop counter
+          long relax_delay)
+#else
+static inline struct optimistic_spin_node *
+osq_wait_next(struct optimistic_spin_queue *lock,   // aka global_osq
+          struct optimistic_spin_node *node,        // aka us
+          struct optimistic_spin_node *prev,        // aka prev, the previous tail of the queue
+          unsigned long thread_number,              // our thread number
+          long relax_delay)
+#endif
 {
     struct optimistic_spin_node *next = NULL;
-    int curr = encode_cpu(cpu_number);
-    int old;
+    int curr = encode_cpu(thread_number);
 
     /*
      * If there is a prev node in queue, then the 'old' value will be
      * the prev node's CPU #, else it's set to OSQ_UNLOCKED_VAL since if
      * we're currently last in queue, then the queue will then become empty.
      */
-    old = prev ? prev->cpu : OSQ_UNLOCKED_VAL;
+    int old = prev ? prev->cpu : OSQ_UNLOCKED_VAL;
 
     for (;;) {
 
@@ -336,21 +718,30 @@ osq_wait_next(struct optimistic_spin_queue *lock,
                 break;
         }
 
-        cpu_relax();
+        CPU_RELAX(relax_delay);
+
+        INCREMENT_COUNTER(counter);
     }
 
     return next;
 }
 
-/* uint64_t *osq is ignored because we use &global_osq instead */
-static bool osq_lock(uint64_t *osq, unsigned long cpu_number)
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+static bool osq_lock(uint64_t *osq, unsigned long thread_number, unsigned long * osq_lock_wait_next_spins, unsigned long * osq_lock_locked_spins, unsigned long * osq_lock_unqueue_spins)
+#else
+static bool osq_lock(uint64_t *osq, unsigned long thread_number)
+#endif
 {
-    /* each cpu core has only one thread spinning on one optimistic_spin_node */
-    struct optimistic_spin_node *node = global_osq_nodepool_ptr + cpu_number;
-    /* optimistic_spin_queue stores the current osq tail globally */
+    (void) osq; // osq is unused; global_osq_nodepool_ptr should have the same value.
+
+    /* each thread spins on one optimistic_spin_node */
+    struct optimistic_spin_node *node = global_osq_nodepool_ptr + thread_number;
+
+    /* optimistic_spin_queue points to the current osq tail */
     struct optimistic_spin_queue *lock = &global_osq;
     struct optimistic_spin_node *prev, *next;
-    int curr = encode_cpu(cpu_number);
+    int curr = encode_cpu(thread_number);
     int old;
     long long back_off = 0;
 
@@ -364,18 +755,23 @@ static bool osq_lock(uint64_t *osq, unsigned long cpu_number)
      * the node fields we just initialised) semantics when updating
      * the lock tail.
      */
-    old = atomic_xchg(&lock->tail, curr);
-    if (old == OSQ_UNLOCKED_VAL)
+
+    old = atomic_xchg(&lock->tail, curr);   // _unconditionally_ put our cpu into tail.
+    if (old == OSQ_UNLOCKED_VAL)            // if tail _was_ empty, then we have acquired the lock.
         return true;
+
+    // if we are here, then there is already someone else ahead of us in the queue.
+
+    // prev is a pointer to the node of the cpu 'old' that obtained the lock before us
 
     prev = cpu_to_node(old);
     node->prev = prev;
 
     /*
-     * osq_lock()            unqueue
+     * osq_lock()               unqueue
      *
      * node->prev = prev        osq_wait_next()
-     * WMB                MB
+     * WMB                      MB
      * prev->next = node        next->prev = prev // unqueue-C
      *
      * Here 'node->prev' and 'next->prev' are the same variable and we need
@@ -393,33 +789,73 @@ static bool osq_lock(uint64_t *osq, unsigned long cpu_number)
      * guaranteed their existence -- this allows us to apply
      * cmpxchg in an attempt to undo our queueing.
      */
+
 #if defined(USE_SMP_COND_LOAD_RELAXED)
+        /*
+         * Wait to acquire the lock or cancellation. Note that need_resched()
+         * will come with an IPI, which will wake smp_cond_load_relaxed() if it
+         * is implemented with a monitor-wait. vcpu_is_preempted() relies on
+         * polling, be careful.
+         */
+
+    // INCREMENT_COUNTER(osq_lock_locked_spins) is inside include/lk_atomics.h:smp_cond_load_relaxed
+
     if (smp_cond_load_relaxed(&node->locked, VAL || (++back_off > unqueue_retry)))
-	return true;
+        return true;
 #else
     while (!READ_ONCE(node->locked)) {
+
         /*
          * TODO: Need to better emulate kernel rescheduling in user space.
          * Because we cannot use need_resched() in user space, we simply
-         * add a upper limit named unqueue_retry to mimic need_resched().
-         * If this limit has been exceeded by back_off times, we will jump
-         * to unqueue path and remove the spinning node from global osq.
+         * add a upper limit named unqueue_retry (-s max_backoff_wait_us)
+         * to mimic need_resched() or the per-cpu fixed backoff_wait_us (-S
+         * cpu:backoff_wait_us).  If this limit has been exceeded by
+         * back_off times, we will jump to unqueue path and remove the
+         * spinning node from global osq.
          */
+
         /*
          * If we need to reschedule bail... so we can block.
          * Use vcpu_is_preempted() to avoid waiting for a preempted
          * lock holder.
          */
+
         //if (need_resched() || vcpu_is_preempted(node_to_cpu(node->prev)))
-        if (++back_off > unqueue_retry) /* DEFAULT_UNQUEUE_RETRY 2 billions */
+
+        if (++back_off > unqueue_retry) /* DEFAULT_UNQUEUE_RETRY is 2 billion */
             goto unqueue;
 
-        cpu_relax();
+        CPU_RELAX(thread_to_relax[thread_number][0]);
+
+        INCREMENT_COUNTER(osq_lock_locked_spins);
     }
-    return true;
-#endif
+    return true;    // we got the lock before unqueue_retry number of times
 
 unqueue:
+#endif
+
+    //
+    // If we are here, we polled node->locked for unqueue_retry number of times
+    // and found it was always 0, i.e. we never won the lock. so we are
+    // attempting to give up.
+    //
+    // step A = remove us from prev's ->next if it points to us.  if we somehow
+    // get granted ->locked=1, then abort at this step (because we obtained the
+    // lock).  for loop continues if prev's -> next is not us, or we are not
+    // serendiptiously locked.
+    //
+    // step B = our prev's ->next WAS pointed to us and we cleared it to NULL
+    // successfully in step A.  Now, using osq_wait_next, we repeatedly try to
+    // clear us from the tail of the lock qeueue if we are the tail of the queue
+    // (in which case osq_wait_next returns NULL and we return false from
+    // osq_lock()), or we clear our ->next and osq_wait_next returns that
+    // pointer that was in our ->next for step C.
+    //
+    // step C = assign  next->prev <---  prev, and assign prev->next to next,
+    // basically removing us from the link.  finally return false.
+    //
+
     /*
      * Step - A  -- stabilize @prev
      *
@@ -428,20 +864,22 @@ unqueue:
      * (or later).
      */
 
-    for (;;) {
-        if (prev->next == node &&
-            cmpxchg(&prev->next, node, NULL) == node)
+    for (;;) {     // make ourselves not in the queue (prev does not point to us)
+        if (prev->next == node &&                      // if prev->next is us (node)
+            cmpxchg(&prev->next, node, NULL) == node)  // then try to clear it out
             break;
 
         /*
          * We can only fail the cmpxchg() racing against an unlock(),
-         * in which case we should observe @node->locked becomming
+         * in which case we should observe @node->locked becoming
          * true.
          */
         if (smp_load_acquire(&node->locked))
             return true;
 
-        cpu_relax();
+        CPU_RELAX(thread_to_relax[thread_number][1]);
+
+        INCREMENT_COUNTER(osq_lock_unqueue_spins);
 
         /*
          * Or we race against a concurrent unqueue()'s step-B, in which
@@ -457,88 +895,172 @@ unqueue:
      * back to @prev.
      */
 
-    next = osq_wait_next(lock, node, prev, cpu_number);
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    next = osq_wait_next(lock, node, prev, thread_number,
+                         osq_lock_wait_next_spins,
+                         thread_to_relax[thread_number][2]);
+#else
+    next = osq_wait_next(lock, node, prev, thread_number,
+                         thread_to_relax[thread_number][2]);
+#endif
     if (!next)
         return false;
 
     /*
      * Step - C -- unlink
      *
-     * @prev is stable because its still waiting for a new @prev->next
+     * @prev is stable because it's still waiting for a new @prev->next
      * pointer, @next is stable because our @node->next pointer is NULL and
      * it will wait in Step-A.
      */
 
-    WRITE_ONCE(next->prev, prev);
-    WRITE_ONCE(prev->next, next);
+    WRITE_ONCE(next->prev, prev);  // we did not get the lock, and we were not at end of queue
+    WRITE_ONCE(prev->next, next);  // so take us out of the queue
 
     return false;
 }
 
-/* uint64_t *osq is ignored because we use &global_osq instead */
-static void osq_unlock(uint64_t *osq, unsigned long cpu_number)
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+void osq_unlock(uint64_t * osq, unsigned long thread_number, unsigned long * osq_unlock_wait_next_spins)
+#else
+void osq_unlock(uint64_t * osq, unsigned long thread_number)
+#endif
 {
+    (void) osq; // osq is unused, but global_osq_nodepool_ptr should point to the same address.
+
     /* optimistic_spin_queue stores the current osq tail globally */
     struct optimistic_spin_queue *lock = &global_osq;
     struct optimistic_spin_node *node, *next;
-    int curr = encode_cpu(cpu_number);
+    int curr = encode_cpu(thread_number);
 
     /*
      * Fast path for the uncontended case.
      */
+
+    // This writes OSQ_UNLOCKED_VAL to the tail if this node is the tail.  If
+    // this node isn't the tail, then the cmpxchg fails.
+
     if (atomic_cmpxchg_release(&lock->tail, curr,
-                      OSQ_UNLOCKED_VAL) == curr)
+                OSQ_UNLOCKED_VAL) == curr) {
         return;
+    }
 
     /*
      * Second most likely case.
      * If there is a next node, notify it.
      */
-    node = global_osq_nodepool_ptr + cpu_number;
-    next = xchg(&node->next, NULL);
-    if (next) {
-        WRITE_ONCE(next->locked, 1);
+
+    node = global_osq_nodepool_ptr + thread_number;     // node = us
+    next = xchg(&node->next, NULL);   // unconditionally clear our node->next.
+    if (next) {                       // if there was a node->next, set its locked to 1.
+        WRITE_ONCE(next->locked, 1);  //     (i.e. the next node now has the lock.)
         return;
     }
 
     /*
      * Wait for another stable next, or get NULL if the queue is empty.
      */
-    next = osq_wait_next(lock, node, NULL, cpu_number);
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    next = osq_wait_next(lock, node, NULL, thread_number,
+                         osq_unlock_wait_next_spins,
+                         thread_to_relax[thread_number][3]);
+#else
+    next = osq_wait_next(lock, node, NULL, thread_number,
+                         thread_to_relax[thread_number][3]);
+#endif
     if (next)
         WRITE_ONCE(next->locked, 1);
 }
 
+// -----------------------------------------------------------------------------
 
-/* standard lockhammer lock_acquire and lock_release interfaces */
-static unsigned long __attribute__((noinline))
-lock_acquire (uint64_t *lock, unsigned long threadnum)
+#ifdef OSQ_LOCK_COUNT_LOOPS
+unsigned long osq_lock_acquire (uint64_t * p_test_lock, unsigned long threadnum, unsigned long * osq_lock_wait_next_spins, unsigned long * osq_lock_locked_spins, unsigned long * osq_lock_unqueue_spins, unsigned long * osq_lock_acquire_backoffs)
+#else
+unsigned long osq_lock_acquire (uint64_t * p_test_lock, unsigned long threadnum)
+#endif
 {
     /*
      * Note: The linux kernel implements additional mutex slow path in mutex.c
-     * __mutex_lock_common() function. We will create another workload which
-     * combines osq_lock and mutex_lock_common. This workload only benchmarks
+     * __mutex_lock_common() function. We may create another test which
+     * combines osq_lock and mutex_lock_common. However, this test only benchmarks
      * osq_lock itself. The osq_lock is different from mcs_queue_spinlock
      * because of tunable unqueue path and backoff sleep time.
      */
-    while (!osq_lock(lock, threadnum)) {
+    unsigned long sleep_blackhole = global_osq_nodepool_ptr[threadnum].sleep_blackhole;
+
+#ifdef OSQ_LOCK_COUNT_LOOPS
+    while (!osq_lock(p_test_lock, threadnum, osq_lock_wait_next_spins, osq_lock_locked_spins, osq_lock_unqueue_spins)) {
+#else
+    while (!osq_lock(p_test_lock, threadnum)) {
+#endif
         /*
          * If still cannot acquire the lock after spinning for unqueue_retry
-         * times, try to backoff and sleep for random microseconds specified
-         * by parameter '-s', by default the maximum sleep time is 0us. Then
-         * reacquire the lock again infinitely until success.
+         * times, try to backoff for a predetermined number of microseconds
+         * specified by parameter '-s'.  The default maximum sleep time is 0us.
+         * Then attempt to reacquire the lock again infinitely until success.
          *
          * This behaves similar to kernel mutex with fine tuning sleep time.
          */
-        usleep((global_osq_nodepool_ptr + threadnum)->random_sleep);
+
+        blackhole(sleep_blackhole);
+
+        INCREMENT_COUNTER(osq_lock_acquire_backoffs);
     }
     return 1;
 }
 
 
-static inline void lock_release (uint64_t *lock, unsigned long threadnum)
+#ifdef OSQ_LOCK_COUNT_LOOPS
+inline void osq_lock_release (uint64_t * p_test_lock, unsigned long threadnum, unsigned long *osq_unlock_wait_next_spins)
 {
-    osq_unlock(lock, threadnum);
+    osq_unlock(p_test_lock, threadnum, osq_unlock_wait_next_spins);
 }
+#else
+inline void osq_lock_release (uint64_t * p_test_lock, unsigned long threadnum)
+{
+    osq_unlock(p_test_lock, threadnum);
+}
+#endif
 
 #endif /* __LINUX_OSQ_LOCK_H */
+
+
+
+/////////////////////////////////////////////////////////
+/*  outline of osq_lock and where the instrumented counters reside cpu_to_relax[]
+
+    osq_lock_acquire
+        osq_lock
+            fast-path loop:
+                while ! node->locked        [[[ spins on our own node ]]]
+                    osq_lock_locked_spins++     // [0] = osq_lock - fast-path loop
+            unqueue path:
+                    step A loop:
+                        looping on prev->next to be us to clear it AND we are ! node->locked
+                            [[[ spins on prev->next and our own node->locked ]]]]
+                            osq_lock_unqueue_spins++    // [1] = osq_lock - unqueue step A loop
+                        go to step B iff we were able to clear prev->next
+                    step B loop:
+                        inside osq_wait_next    [[[ spins on global tail and our own node->next ]]]
+                            if we are the (tail) end of the queue, remove us from the queue. return false.
+                            if we are not the end of the queue, try to clear our -> next pointer.
+                            if our -> next pointer was clear:
+                                osq_lock_wait_next_spins++   // [2] = osq_lock - unqueue step B osq_wait_next loop
+
+
+    osq_lock_release
+        osq_unlock
+            osq_wait_next
+                inside osq_wait_next    [[[ spins on global tail and our own node->next ]]]
+                    if we are the (tail) end of the queue, remove us from the queue.
+                    if we are not the end of the queue, try to clear our ->next pointer.
+                    if our -> next pointer was clear:
+                        osq_unlock_wait_next_spins++    // [3] = osq_unlock - osq_wait_next loop
+
+*/
+
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/ext/linux/ticket_spinlock.h
+++ b/ext/linux/ticket_spinlock.h
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Based on Linux 4.13 */
+/* aarch64 version is based on Linux 3.13 */
 
 #include "atomics.h"
 
@@ -109,3 +109,5 @@ asm volatile (
 : );
 #endif
 }
+
+/* vim: set tabstop=8 shiftwidth=8 softtabstop=8 noexpandtab: */

--- a/ext/mysql/event_mutex.h
+++ b/ext/mysql/event_mutex.h
@@ -22,7 +22,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #undef initialize_lock
 #endif
 
-#define initialize_lock(lock, threads) event_mutex_init(lock, threads)
+#define initialize_lock(lock, pinorder, threads) event_mutex_init(lock, threads)
 
 #include "atomics.h"
 #include "ut_atomics.h"

--- a/ext/mysql/include/ut_atomics.h
+++ b/ext/mysql/include/ut_atomics.h
@@ -19,12 +19,6 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #define os_rmb __atomic_thread_fence(__ATOMIC_ACQUIRE)
 #define os_wmb __atomic_thread_fence(__ATOMIC_RELEASE)
 
-#if defined(__x86_64__)
-#define UT_RELAX_CPU() asm volatile ("rep; nop")
-#elif defined(__aarch64__)
-// Theoretically we could emit a yield here but MySQL doesn't do it
-// and most ARM cores are likely to NOP it anyway
-#define UT_RELAX_CPU() asm volatile ("isb":::"memory")
-#else
-#define UT_RELAX_CPU() asm volatile ("":::"memory")
-#endif
+#include "cpu_relax.h"
+
+#define UT_RELAX_CPU() __cpu_relax()

--- a/ext/pagemap/include/pagemap.h
+++ b/ext/pagemap/include/pagemap.h
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: Copyright 2020 Ciro Santilli
+ *
+ * pagemap.h is retrieved from
+ * https://raw.githubusercontent.com/cirosantilli/linux-kernel-module-cheat/master/lkmc/pagemap.h
+ */
+
+/* https://cirosantilli.com/linux-kernel-module-cheat#userland-physical-address-experiments
+ * https://cirosantilli.com/linux-kernel-module-cheat#pagemap-dump-out
+ *
+ * This file is dual licensed as both 3-Clause BSD and GPLv3.
+ */
+
+#ifndef LKMC_PAGEMAP_H
+#define LKMC_PAGEMAP_H
+
+#define _XOPEN_SOURCE 700
+#include <fcntl.h> /* open */
+#include <stdint.h> /* uint64_t  */
+#include <stdio.h> /* snprintf */
+#include <sys/types.h>
+#include <unistd.h> /* pread, sysconf */
+
+/* Format documented at:
+ * https://github.com/torvalds/linux/blob/v4.9/Documentation/vm/pagemap.txt
+ */
+typedef struct {
+    uint64_t pfn : 55;
+    unsigned int soft_dirty : 1;
+    unsigned int file_page : 1;
+    unsigned int swapped : 1;
+    unsigned int present : 1;
+} LkmcPagemapEntry;
+
+/* Parse the pagemap entry for the given virtual address.
+ *
+ * @param[out] entry      the parsed entry
+ * @param[in]  pagemap_fd file descriptor to an open /proc/pid/pagemap file
+ * @param[in]  vaddr      virtual address to get entry for
+ * @return                0 for success, 1 for failure
+ */
+int lkmc_pagemap_get_entry(LkmcPagemapEntry *entry, int pagemap_fd, uintptr_t vaddr) {
+    size_t nread;
+    ssize_t ret;
+    uint64_t data;
+    uintptr_t vpn;
+
+    vpn = vaddr / sysconf(_SC_PAGE_SIZE);
+    nread = 0;
+    while (nread < sizeof(data)) {
+        ret = pread(
+            pagemap_fd,
+            ((uint8_t*)&data) + nread,
+            sizeof(data) - nread,
+            vpn * sizeof(data) + nread
+        );
+        nread += ret;
+        if (ret <= 0) {
+            return 1;
+        }
+    }
+    entry->pfn = data & (((uint64_t)1 << 55) - 1);
+    entry->soft_dirty = (data >> 55) & 1;
+    entry->file_page = (data >> 61) & 1;
+    entry->swapped = (data >> 62) & 1;
+    entry->present = (data >> 63) & 1;
+    return 0;
+}
+
+/* Convert the given virtual address to physical using /proc/PID/pagemap.
+ *
+ * @param[out] paddr physical address
+ * @param[in]  pid   process to convert for
+ * @param[in]  vaddr virtual address to get entry for
+ * @return           0 for success, 1 for failure
+ */
+int lkmc_pagemap_virt_to_phys_user(uintptr_t *paddr, pid_t pid, uintptr_t vaddr) {
+    char pagemap_file[BUFSIZ];
+    int pagemap_fd;
+
+    snprintf(pagemap_file, sizeof(pagemap_file), "/proc/%ju/pagemap", (uintmax_t)pid);
+    pagemap_fd = open(pagemap_file, O_RDONLY);
+    if (pagemap_fd < 0) {
+        return 1;
+    }
+    LkmcPagemapEntry entry;
+    if (lkmc_pagemap_get_entry(&entry, pagemap_fd, vaddr)) {
+        return 1;
+    }
+    close(pagemap_fd);
+    *paddr = (entry.pfn * sysconf(_SC_PAGE_SIZE)) + (vaddr % sysconf(_SC_PAGE_SIZE));
+    return 0;
+}
+
+#endif

--- a/ext/sms/base/cpu.h
+++ b/ext/sms/base/cpu.h
@@ -8,19 +8,11 @@
 #define CACHE_LINE 128
 #endif
 
+#include "cpu_relax.h"
+
 static inline void doze(void)
 {
-#if defined(__ARM_ARCH)
-    // YIELD hints the CPU to switch to another thread if available
-    // but otherwise executes as a NOP
-    // ISB flushes the pipeline, then restarts. This is guaranteed to stall
-    // the CPU a number of cycles
-    __asm__ volatile("isb" : : : "memory");
-#elif defined(__x86_64__)
-    __asm__ volatile("pause" : : : "memory");
-#else
-#error Please add support for your CPU in cpu.h
-#endif
+    __cpu_relax();
 }
 
 int num_cpus(void);

--- a/ext/sms/base/llsc.h
+++ b/ext/sms/base/llsc.h
@@ -41,7 +41,7 @@ static inline uint32_t ll(uint32_t *var, int mm)
                    : );
     //Barrier after an acquiring load
     if (mm == __ATOMIC_ACQUIRE)
-	dmb();
+        dmb();
     return old;
 }
 #define ll32(a, b) ll((a), (b))
@@ -52,7 +52,7 @@ static inline uint32_t sc(uint32_t *var, uint32_t neu, int mm)
     uint32_t ret;
     //Barrier before a releasing store
     if (mm == __ATOMIC_RELEASE)
-	dmb();
+        dmb();
     __asm volatile("strex %0, %1, [%2]"
                    : "=&r" (ret)
                    : "r" (neu), "r" (var)
@@ -70,7 +70,7 @@ static inline uint64_t lld(uint64_t *var, int mm)
                    : );
     //Barrier after an acquiring load
     if (mm == __ATOMIC_ACQUIRE)
-	dmb();
+        dmb();
     return old;
 }
 #define ll64(a, b) lld((a), (b))
@@ -81,7 +81,7 @@ static inline uint32_t scd(uint64_t *var, uint64_t neu, int mm)
     uint32_t ret;
     //Barrier before a releasing store
     if (mm == __ATOMIC_RELEASE)
-	dmb();
+        dmb();
     __asm volatile("strexd %0, %1, %H1, [%2]"
                    : "=&r" (ret)
                    : "r" (neu), "r" (var)
@@ -108,7 +108,7 @@ static inline uint8_t ll8(uint8_t *var, int mm)
                    : "r" (var)
                    : );
     else
-	abort();
+        abort();
     return old;
 }
 
@@ -126,7 +126,7 @@ static inline uint16_t ll16(uint16_t *var, int mm)
                    : "r" (var)
                    : );
     else
-	abort();
+        abort();
     return old;
 }
 
@@ -144,7 +144,7 @@ static inline uint32_t ll32(uint32_t *var, int mm)
                    : "r" (var)
                    : );
     else
-	abort();
+        abort();
     return old;
 }
 
@@ -163,7 +163,7 @@ static inline uint8_t sc8(uint8_t *var, uint8_t neu, int mm)
                    : "r" (neu), "r" (var)
                    : );
     else
-	abort();
+        abort();
     return ret;
 }
 
@@ -182,7 +182,7 @@ static inline uint32_t sc32(uint32_t *var, uint32_t neu, int mm)
                    : "r" (neu), "r" (var)
                    : );
     else
-	abort();
+        abort();
     return ret;
 }
 
@@ -200,7 +200,7 @@ static inline uint64_t ll(uint64_t *var, int mm)
                    : "r" (var)
                    : );
     else
-	abort();
+        abort();
     return old;
 }
 #define ll64(a, b) ll((a), (b))
@@ -220,7 +220,7 @@ static inline uint32_t sc(uint64_t *var, uint64_t neu, int mm)
                    : "r" (neu), "r" (var)
                    : );
     else
-	abort();
+        abort();
     return ret;
 }
 #define sc64(a, b, c) sc((a), (b), (c))
@@ -248,7 +248,7 @@ static inline __int128 lld(__int128 *var, int mm)
                    : "r" (var)
                    : );
     else
-	abort();
+        abort();
     return old.i128;
 #else
     __int128 old;
@@ -263,7 +263,7 @@ static inline __int128 lld(__int128 *var, int mm)
                    : "r" (var)
                    : );
     else
-	abort();
+        abort();
     return old;
 #endif
 }
@@ -288,7 +288,7 @@ static inline uint32_t scd(__int128 *var, __int128 neu, int mm)
                      "r" (var)
                    : );
     else
-	abort();
+        abort();
     return ret;
 #else
     uint32_t ret;
@@ -303,7 +303,7 @@ static inline uint32_t scd(__int128 *var, __int128 neu, int mm)
                    : "r" (neu), "r" (var)
                    : );
     else
-	abort();
+        abort();
     return ret;
 #endif
 }

--- a/ext/sms/clh_spinlock.h
+++ b/ext/sms/clh_spinlock.h
@@ -34,7 +34,7 @@
  * August 6 2018
  *
  * Description:
- * CLH (Craig Landin Hagersten) spinlock is a queue-based spinlock that each
+ * CLH (Craig, Landin, and Hagersten) spinlock is a queue-based spinlock that each
  * node spins on previous node's wait status. CLH spinlock is starvation-free
  * and has FCFS (first come, first served) order. Because each thread spins
  * on the previous node created by another thread, CLH's performance may be
@@ -95,7 +95,7 @@
 #undef thread_local_init
 #endif
 
-#define initialize_lock(lock, threads) clh_lock_init(lock, threads)
+#define initialize_lock(lock, pinorder, threads) clh_lock_init(lock, threads)
 #define parse_test_args(args, argc, argv) clh_parse_args(args, argc, argv)
 #define thread_local_init(smtid) clh_thread_local_init(smtid)
 
@@ -139,7 +139,7 @@ static struct clh_node_pointer *clh_nodeptr;  // clh node pointer array
 static struct clh_node *clh_nodepool;  // clh node struct array
 
 /* additional parameter to enable WFE(default) or disable WFE */
-static void clh_parse_args(test_args unused, int argc, char** argv) {
+static void clh_parse_args(test_args_t * unused, int argc, char** argv) {
     int i = 0;
 #if defined(__aarch64__)
     without_wfe = false;
@@ -178,8 +178,12 @@ static inline void clh_lock_init(uint64_t *u64_lock, unsigned long num_cores)
     *u64_lock = (uint64_t)&global_clh_lock;
 
     /* calloc will initialize all memory to zero automatically */
+    if (clh_nodeptr) free(clh_nodeptr);
     clh_nodeptr = calloc(num_cores, sizeof(struct clh_node_pointer));
     if (clh_nodeptr == NULL) exit(errno);
+
+
+    if (clh_nodepool) free(clh_nodepool);
     clh_nodepool = calloc(num_cores, sizeof(struct clh_node));
     if (clh_nodepool == NULL) exit(errno);
 
@@ -260,3 +264,5 @@ static inline void lock_release (uint64_t *lock, unsigned long threadnum)
     clh_unlock(clh_nodeptr[threadnum].ptr, threadnum);
     clh_nodeptr[threadnum].ptr = prev;
 }
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/ext/tbb/include/tbb.h
+++ b/ext/tbb/include/tbb.h
@@ -48,6 +48,7 @@
 #define _GNU_SOURCE
 
 #include "atomics.h"
+#include "cpu_relax.h"
 
 /* Non default configurations */
 // #define USE_LOCAL
@@ -76,11 +77,7 @@
  */
 static inline void machine_pause (int32_t delay) {
     while(delay>0) {
-#if defined(__x86_64__)
-        asm volatile ("pause" : : : "memory" );
-#elif defined(__aarch64__)
-        asm volatile ("yield" : : : "memory" );
-#endif  /* ARCH */
+        __cpu_relax();
         delay--;
     }
 }
@@ -97,9 +94,9 @@ static inline void machine_pause (int32_t delay) {
  * The atomics.h is aware of USE_LSE configuration
  * So no need to do anything here.
  */
-#define __TBB_machine_cmpswp8(P,V,C)        cas64_acquire_release(P,V,C)
-#define __TBB_machine_fetchadd8(P,V)        fetchadd64_acquire_release(P,V)
-#define __TBB_machine_fetchadd8release(P,V) fetchadd64_acquire_release(P,V)
+#define __TBB_machine_cmpswp8(P,V,C)        cas64_acquire_release((unsigned long *) P,V,C)
+#define __TBB_machine_fetchadd8(P,V)        fetchadd64_acquire_release((unsigned long *) P,V)
+#define __TBB_machine_fetchadd8release(P,V) fetchadd64_acquire_release((unsigned long *) P,V)
 
 static inline void __TBB_machine_or(volatile void* operand, uint64_t addend) {
 #if defined(__x86_64__)
@@ -302,3 +299,6 @@ static inline void __TBB_AtomicAND(void* operand, uintptr_t addend) {
 }
 #endif  /* __TBB_AtomicAND */
 #endif  /* __TBB_H */
+
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/ext/tbb/tbb_spin_rw_mutex.h
+++ b/ext/tbb/tbb_spin_rw_mutex.h
@@ -131,7 +131,7 @@
 #undef parse_test_args
 #endif
 
-#define initialize_lock(lock, threads) tbb_init_locks(lock, threads)
+#define initialize_lock(lock, pinorder, threads) tbb_init_locks(lock, threads)
 #define parse_test_args(args, argc, argv) tbb_parse_args(args, argc, argv)
 
 #include "tbb.h"
@@ -176,7 +176,7 @@ void tbb_check_strtoul(int rval, char* endptr) {
     }
 }
 
-void tbb_parse_args(test_args unused, int argc, char** argv) {
+void tbb_parse_args(test_args_t * unused, int argc, char** argv) {
     int i = 0;
     char *endptr;
 
@@ -218,10 +218,13 @@ void tbb_parse_args(test_args unused, int argc, char** argv) {
 void tbb_init_locks (unsigned long *lock, unsigned long cores) {
     unsigned i;
     rw_mask = ((1UL<<log2_ratio)-1);
+    if (rw_counts) { free(rw_counts); }
     rw_counts = (rw_count_t*) malloc(cores * sizeof(rw_count_t));
 
     DBG("On each thread, for every %lu readers there will be 1 writer\n", rw_mask);
     DBG("CPU mask 0x%lx will be readers\n", reader_cpu_mask);
+
+    // XXX: since reader_cpu_mask is unsigned long, this only supports up to 64 CPUs.
 
     for (i=0; i < cores; ++i) {
         rw_counts[i].pure_reader = (reader_cpu_mask & (1UL << i)) ? 1 : 0;
@@ -304,3 +307,5 @@ lock_release (unsigned long *lock, unsigned long threadnum) {
     return;
 }
 #endif /* __TBB_spin_mutex_H */
+
+/* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Improve run-to-run reproducibility
- add time-based measurement mode so that no threads finish early to let the remaining threads have less competition
- reuse the same physical address run-to-run by allocating the lock memory from a persistent hugetlb page
- detect cpufreq driver and governors that could affect performance under load
- improve thread cleanup in case of crash or test timeout

Usability for scaling studies
- any-cpu pinorder assignment; CPU0 does not need to be used explicitly/implicitly
- multiple measurements per run, permuting iterations, critical/parallel durations, and num_threads/pinorders
- results capture to JSON, with a script provided to display/compare multiple JSONs
- per-thread fairness and execution duration data
- aarch64: runtime support to disable LSE in outline atomics

Improve maintainability
- separate compilation of measurement code so that the test harness does not use the same target optimizations as the lock implementation; faster compilation
- rewritten Makefile with automatic dependencies, separate build directories, parallel make, and phony targets for building all variants in one make command
- implement a __cpu_relax() macro to centralize its implementation across tests
- long options support and help screen
- vim modelines for per-file whitespace type and indentation spacing

Test-specific changes
- osq_lock: support smp_cond_load_relaxed macro, provide more control over relax and backoff durations
- jvm_objectmonitor: more accurately represent jdk-9, fix a use-after-free, reduce the presence of malloc
- cas_event_mutex: allow use of __atomic intrinsic on aarch64
- various: quell compiler warnings, support compilation with clang, document limitations/TODO