### PR TITLE
Update the adaptation of the some locks under the RISCV architecture

### DIFF
--- a/benchmarks/lockhammer/include/cpu_relax.h
+++ b/benchmarks/lockhammer/include/cpu_relax.h
@@ -63,9 +63,18 @@ static inline void __cpu_relax(void) {
 #endif
 #endif // __x86_64__
 
+#ifdef __riscv
+#if defined(RELAX_IS_EMPTY)
+	asm volatile ("" : : : "memory");
+#elif defined(RELAX_IS_NOP)
+	asm volatile ("nop" : : : "memory");
+#elif defined(RELAX_IS_NOTHING)
+	
+#endif
+#endif // __riscv
+
     }
 }
-
 #endif // CPU_RELAX_H
 
 /* vim: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/benchmarks/lockhammer/src/args.c
+++ b/benchmarks/lockhammer/src/args.c
@@ -129,6 +129,8 @@ static size_t get_ctr_erg_bytes(void) {
     return ERG_words * 4;
 #elif defined(__x86_64__)
     return 64;
+#elif defined(__riscv)
+	return 64;
 #else
 #error neither __aarch64__ nor __x86_64__ are defined in get_ctr_erg_bytes()
 #endif

--- a/benchmarks/lockhammer/src/measure.c
+++ b/benchmarks/lockhammer/src/measure.c
@@ -203,6 +203,9 @@ void NOINLINE blackhole(unsigned long iters) {
 #endif
 #elif __x86_64__
     asm volatile (".p2align 4; 1: add $-1, %0; jne 1b" : "+r" (iters) );
+#elif __riscv
+	asm volatile (
+        ".p2align 4; 1: addi %0, %0, -1; bnez %0, 1b" :"+r" (iters) : "0" (iters));
 #endif
 }
 

--- a/ext/linux/include/lk_barrier.h
+++ b/ext/linux/include/lk_barrier.h
@@ -45,6 +45,19 @@
 #define smp_rmb()	dmb(ishld)
 #define smp_wmb()	dmb(ishst)
 
+#elif defined(__riscv)
+
+#define RISCV_FENCE_ASM(p, s)       "\tfence " #p "," #s "\n"
+#define RISCV_FENCE(p, s) \
+	({ __asm__ __volatile__ (RISCV_FENCE_ASM(p, s) : : : "memory"); })
+
+#define mb()      RISCV_FENCE(iorw, iorw)
+#define rmb()     RISCV_FENCE(ir, ir)
+#define wmb()     RISCV_FENCE(ow, ow)
+#define smp_mb()  RISCV_FENCE(rw, rw)
+#define smp_rmb() RISCV_FENCE(r, r)
+#define smp_wmb() RISCV_FENCE(w, w)
+
 #else /* No Arch */
     /* TODO: No Arch Default */
 #endif /* __x86_64__ */

--- a/ext/linux/include/lk_cmpxchg.h
+++ b/ext/linux/include/lk_cmpxchg.h
@@ -458,6 +458,190 @@ __XCHG_GEN(_mb)
 #define atomic_xchg_release(v, new) xchg_release(&((v)->counter), (new))
 #define atomic_xchg(v, new)     xchg(&((v)->counter), (new))
 
+
+#elif defined(__riscv)
+
+#define BITS_PER_BYTE 8
+#define GENMASK(h, l) \
+    (((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+#define BITS_PER_LONG 64
+#define RISCV_FENCE_ASM(p, s)       "\tfence " #p "," #s "\n"
+#define RISCV_FENCE(p, s) \
+	({ __asm__ __volatile__ (RISCV_FENCE_ASM(p, s) : : : "memory"); })
+#define RISCV_ACQUIRE_BARRIER       RISCV_FENCE_ASM(r, rw)
+#define RISCV_RELEASE_BARRIER       RISCV_FENCE_ASM(rw, w)
+#define RISCV_FULL_BARRIER      RISCV_FENCE_ASM(rw, rw)
+
+#define __arch_xchg_masked(sc_sfx, prepend, append, r, p, n)        \
+({                                  \
+    u32 *__ptr32b = (u32 *)((ulong)(p) & ~0x3);         \
+    ulong __s = ((ulong)(p) & (0x4 - sizeof(*p))) * BITS_PER_BYTE;  \
+    ulong __mask = GENMASK(((sizeof(*p)) * BITS_PER_BYTE) - 1, 0)   \
+            << __s;                     \
+    ulong __newx = (ulong)(n) << __s;               \
+    ulong __retx;                           \
+    ulong __rc;                         \
+                                    \
+    __asm__ __volatile__ (                      \
+           prepend                          \
+           "0:  lr.w %0, %2\n"                  \
+           "    and  %1, %0, %z4\n"             \
+           "    or   %1, %1, %z3\n"             \
+           "    sc.w" sc_sfx " %1, %1, %2\n"            \
+           "    bnez %1, 0b\n"                  \
+           append                           \
+           : "=&r" (__retx), "=&r" (__rc), "+A" (*(__ptr32b))   \
+           : "rJ" (__newx), "rJ" (~__mask)              \
+           : "memory");                     \
+                                    \
+    r = (__typeof__(*(p)))((__retx & __mask) >> __s);       \
+})
+
+#define __arch_xchg(sfx, prepend, append, r, p, n)          \
+({                                  \
+    __asm__ __volatile__ (                      \
+        prepend                         \
+        "   amoswap" sfx " %0, %2, %1\n"            \
+        append                          \
+        : "=r" (r), "+A" (*(p))                 \
+        : "r" (n)                       \
+        : "memory");                        \
+})
+
+#define _arch_xchg(ptr, new, sc_sfx, swap_sfx, prepend,         \
+           sc_append, swap_append)              \
+({                                  \
+    __typeof__(ptr) __ptr = (ptr);                  \
+    __typeof__(*(__ptr)) __new = (new);             \
+    __typeof__(*(__ptr)) __ret;                 \
+                                    \
+    switch (sizeof(*__ptr)) {                   \
+    case 1:                             \
+    case 2:                             \
+        __arch_xchg_masked(sc_sfx, prepend, sc_append,      \
+                   __ret, __ptr, __new);        \
+        break;                          \
+    case 4:                             \
+        __arch_xchg(".w" swap_sfx, prepend, swap_append,    \
+                  __ret, __ptr, __new);         \
+        break;                          \
+    case 8:                             \
+        __arch_xchg(".d" swap_sfx, prepend, swap_append,    \
+                  __ret, __ptr, __new);         \
+        break;                          \
+    default:                            \
+    }                               \
+    (__typeof__(*(__ptr)))__ret;                    \
+})
+
+#define arch_xchg(ptr, x)                       \
+    _arch_xchg(ptr, x, ".rl", ".aqrl", "", RISCV_FULL_BARRIER, "")
+
+
+#define __arch_cmpxchg_masked(sc_sfx, prepend, append, r, p, o, n)  \
+({                                  \
+    u32 *__ptr32b = (u32 *)((ulong)(p) & ~0x3);         \
+    ulong __s = ((ulong)(p) & (0x4 - sizeof(*p))) * BITS_PER_BYTE;  \
+    ulong __mask = GENMASK(((sizeof(*p)) * BITS_PER_BYTE) - 1, 0)   \
+            << __s;                     \
+    ulong __newx = (ulong)(n) << __s;               \
+    ulong __oldx = (ulong)(o) << __s;               \
+    ulong __retx;                           \
+    ulong __rc;                         \
+                                    \
+    __asm__ __volatile__ (                      \
+        prepend                         \
+        "0: lr.w %0, %2\n"                  \
+        "   and  %1, %0, %z5\n"             \
+        "   bne  %1, %z3, 1f\n"             \
+        "   and  %1, %0, %z6\n"             \
+        "   or   %1, %1, %z4\n"             \
+        "   sc.w" sc_sfx " %1, %1, %2\n"            \
+        "   bnez %1, 0b\n"                  \
+        append                          \
+        "1:\n"                          \
+        : "=&r" (__retx), "=&r" (__rc), "+A" (*(__ptr32b))  \
+        : "rJ" ((long)__oldx), "rJ" (__newx),           \
+          "rJ" (__mask), "rJ" (~__mask)             \
+        : "memory");                        \
+                                    \
+    r = (__typeof__(*(p)))((__retx & __mask) >> __s);       \
+})
+
+#define __arch_cmpxchg(lr_sfx, sc_sfx, prepend, append, r, p, co, o, n) \
+({                                  \
+    register unsigned int __rc;                 \
+                                    \
+    __asm__ __volatile__ (                      \
+        prepend                         \
+        "0: lr" lr_sfx " %0, %2\n"              \
+        "   bne  %0, %z3, 1f\n"             \
+        "   sc" sc_sfx " %1, %z4, %2\n"         \
+        "   bnez %1, 0b\n"                  \
+        append                          \
+        "1:\n"                          \
+        : "=&r" (r), "=&r" (__rc), "+A" (*(p))          \
+        : "rJ" (co o), "rJ" (n)                 \
+        : "memory");                        \
+})
+
+#define _arch_cmpxchg(ptr, old, new, sc_sfx, prepend, append)       \
+({                                  \
+    __typeof__(ptr) __ptr = (ptr);                  \
+    __typeof__(*(__ptr)) __old = (old);             \
+    __typeof__(*(__ptr)) __new = (new);             \
+    __typeof__(*(__ptr)) __ret;                 \
+                                    \
+    switch (sizeof(*__ptr)) {                   \
+    case 1:                             \
+    case 2:                             \
+        __arch_cmpxchg_masked(sc_sfx, prepend, append,      \
+                    __ret, __ptr, __old, __new);    \
+        break;                          \
+    case 4:                             \
+        __arch_cmpxchg(".w", ".w" sc_sfx, prepend, append,  \
+                __ret, __ptr, (long), __old, __new);    \
+        break;                          \
+    case 8:                             \
+        __arch_cmpxchg(".d", ".d" sc_sfx, prepend, append,  \
+                __ret, __ptr, /**/, __old, __new);  \
+        break;                          \
+    default:                            \
+    }                               \
+    (__typeof__(*(__ptr)))__ret;                    \
+})
+
+#define arch_cmpxchg(ptr, o, n)                     \
+    _arch_cmpxchg((ptr), (o), (n), ".rl", "", " fence rw, rw\n")
+
+#define atomic_cmpxchg_acquire(ptr, o, n) \
+	_arch_cmpxchg(&((ptr)->counter), (o), (n), "", "", RISCV_ACQUIRE_BARRIER)
+#define atomic_cmpxchg_relaxed(ptr, o, n)                 \
+	_arch_cmpxchg(&((ptr)->counter), (o), (n), "", "", "")
+#define atomic_cmpxchg_release(ptr, o, n) \
+	_arch_cmpxchg(&((ptr)->counter), (o), (n), "", RISCV_RELEASE_BARRIER, "")
+#define atomic_cmpxchg(ptr, o, n)  \
+	_arch_cmpxchg(&((ptr)->counter), (o), (n), ".rl", "", " fence rw, rw\n")
+#define atomic_xchg_relaxed(ptr, x)                   \
+	_arch_xchg(&((ptr)->counter), x, "", "", "", "", "")
+#define atomic_xchg_acquire(ptr, x)                   \
+	_arch_xchg(&((ptr)->counter), x, "", "", "",                  \
+		RISCV_ACQUIRE_BARRIER, RISCV_ACQUIRE_BARRIER)
+#define atomic_xchg_release(ptr, x) \
+	_arch_xchg(&((ptr)->counter), x, "", "", RISCV_RELEASE_BARRIER, "", "")
+#define atomic_xchg(ptr, x) \
+	_arch_xchg(&((ptr)->counter), x, ".rl", ".aqrl", "", RISCV_FULL_BARRIER, "")
+	
+#define xchg(ptr, x)                          \
+({                                  \
+    arch_xchg((ptr), (x));                      \
+})
+
+#define cmpxchg(ptr, o, n)                   \
+({                                  \
+    arch_cmpxchg((ptr), (o), (n));                  \
+})
+
 #else /* Unknown Arch */
     /* TODO: No Arch Default */
 #endif /* __x86_64__ */

--- a/ext/sms/base/build_config.h
+++ b/ext/sms/base/build_config.h
@@ -17,6 +17,9 @@
 #elif defined(__i386__)
 #define CONFIG_ARCH_X86
 #define CONFIG_ARCH_32BIT
+#elif defined(__riscv)
+#define CONFIG_ARCH_RISCV64
+#define CONFIG_ARCH_64BIT
 #endif
 
 #if !defined(CONFIG_ARCH_64BIT) && !defined(CONFIG_ARCH_32BIT)


### PR DESCRIPTION
Updated the adaptation of the following locks under the RISCV architecture (lh_swap_mutex,lh_cas_rw_lock,lh_cas_lockref,lh_incdec_refcount), as well as the support of the entire test framework for the RISCV architecture